### PR TITLE
Website post editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,8 +163,8 @@
       bottom
       right
     >
-      <div>{{ snackbar.message }}</div>
-      <div>{{ snackbar.submessage }}</div>
+      <div v-html="snackbar.message"></div>
+      <div v-html="snackbar.submessage"></div>
     </v-snackbar>
   </v-app>
 

--- a/index.html
+++ b/index.html
@@ -212,6 +212,11 @@
 
   <script src="https://cdn.jsdelivr.net/npm/vue-tippy/dist/vue-tippy.min.js"></script>
 
+  <!-- Post form -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"
+    integrity="sha512-CSBhVREyzHAjAFfBlIBakjoRUKp5h7VSweP0InR/pAJyptH7peuhCsqAI/snV+TwZmXZqoUklpXp6R6wMnYf5Q=="
+    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
 <!-- stores -->
 <script src="./stores/discordAuthStore.js"></script>
 <script src="./stores/discordUserStore.js"></script>

--- a/index.html
+++ b/index.html
@@ -199,12 +199,10 @@
   <script src="https://rawgit.com/juijs/vue-graph/master/dist/vue-graph.js"></script>
 
 
-  <!--
-  marked should probably be updated to the newest version sometime (4.0.x)
-  but would need another package for sanitization, because they removed the functionality in version 0.7.0
-  DO NOT IGNORE THIS WARNING ROLF!!!!!!!!!! @TheRolfFR @TheRolfFR
-  -->
-  <script src="https://cdn.jsdelivr.net/npm/marked@0.6.3/marked.min.js"></script>
+  <!-- Add-on Form -->
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"
+    integrity="sha256-OO3w+WHBzLKHiAuI8S83B3X8ZbLigifu4hXoSc2+m7w=" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked@5/lib/marked.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1.27.0/prism.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/vue-prism-editor@1.3.0/dist/prismeditor.umd.production.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/d3@7.3.0/dist/d3.min.js"></script>

--- a/pages/addon/addonForm.js
+++ b/pages/addon/addonForm.js
@@ -163,10 +163,9 @@ export default {
 
         <!-- Addon description preview -->
         <v-container
-          id="addon-description-preview"
+          id="description-preview"
           v-if="submittedForm.description && submittedForm.description.length > 0"
           class="markdown"
-          style="background-color: rgba(33,33,33,1); border-radius: 5px;"
           v-html="$root.compiledMarkdown(submittedForm.description)"
         />
 

--- a/pages/posts/confirm.js
+++ b/pages/posts/confirm.js
@@ -1,0 +1,67 @@
+/* global axios */
+
+export default {
+  name: 'confirm',
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    message: {
+      type: String,
+      required: true,
+    }
+  },
+  template: `
+  <v-dialog
+      v-model="opened"
+      max-width="600"
+    >
+      <v-card>
+        <v-card-title class="headline">{{ title }}</v-card-title>
+        <v-card-text>
+          <v-form ref="form" lazy-validation>
+            <p v-html="message"></p>
+            <slot></slot>
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            color="darken-1"
+            text
+            @click="onCancel"
+          >
+            {{ $root.lang('global.btn.cancel') }}
+          </v-btn>
+          <v-btn
+            color="error darken-1"
+            @click="onSubmit"
+          >
+            {{ $root.lang('global.btn.yes') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  `,
+  data: function () {
+    return {
+      opened: false,
+      data: undefined
+    }
+  },
+  methods: {
+    openDialog(data) {
+      this.data = data
+      this.opened = true
+    },
+    onCancel() {
+      this.opened = false
+      this.$emit('cancel')
+    },
+    onSubmit() {
+      this.opened = false
+      this.$emit('submit', this.data)
+    }
+  }
+}

--- a/pages/posts/datefield.js
+++ b/pages/posts/datefield.js
@@ -1,0 +1,54 @@
+export default {
+	name: 'date-field',
+	props: {
+		format: {
+			type: String,
+			required: false,
+			default: () => "DD-MM-YYYY"
+		},
+		value: {
+			type: String,
+			required: true
+		},
+		invalidMessage: {
+			type: String,
+			required: true
+		}
+	},
+	template: `
+	<v-text-field
+		type="date"
+		v-model="content"
+		v-bind="$attrs"
+		@change="handleInput"
+	/>`,
+	data() {
+		return {
+			content: this.value
+		}
+	},
+	watch: {
+		value: {
+			handler: function () {
+				const mom = moment(this.value, this.format)
+				if (mom.isValid())
+					this.content = mom.format("YYYY-MM-DD")
+				else
+					this.$emit('error', this.invalidMessage)
+			},
+			immediate: true
+		}
+	},
+	methods: {
+		handleInput(v) {
+			let mom = moment(v, "YYYY-MM-DD")
+			console.log(mom)
+			if (mom.isValid()) {
+				const outVal = mom.format(this.format)
+				console.log(outVal)
+				this.$emit('input', outVal)
+			} else
+				this.$emit('error', this.invalidMessage);
+		}
+	}
+}

--- a/pages/posts/downloadfield.js
+++ b/pages/posts/downloadfield.js
@@ -1,0 +1,70 @@
+export default {
+	name: 'download-field',
+	props: {
+		value: {
+			type: Object,
+			required: true
+		},
+		rulesName: {
+			type: Array,
+			required: true
+		},
+		"rulesURL": {
+			type: Array,
+			required: true
+		}
+	},
+	template: `
+	<v-row dense v-bind="$attrs">
+		<v-col cols="2"><v-text-field
+			class="mb-0"
+			v-model="name"
+			:label="$root.lang('posts.form.downloads.name.label')"
+			:placeholder="$root.lang('posts.form.downloads.name.placeholder')"
+			:hint="$root.lang('posts.form.downloads.name.hint')"
+			:rules="rulesName"
+			@change="handleName"
+		/></v-col>
+		<v-col cols="10"><v-text-field
+			class="mb-0"
+			v-model="url"
+			:label="$root.lang('posts.form.downloads.url.label')"
+			:placeholder="$root.lang('posts.form.downloads.url.placeholder')"
+			:hint="$root.lang('posts.form.downloads.url.hint')"
+			:rules="rulesURL"
+			@change="handleURL"
+		/></v-col>
+	</v-row>`,
+	data() {
+		return {
+			name: this.value.name,
+			url: this.value.url
+		}
+	},
+	watch: {
+		value: {
+			handler: function (n, o) {
+				if (JSON.stringify(n) === JSON.stringify(o)) return;
+				this.name = this.value.name
+				this.url = this.value.url
+			},
+			immediate: true
+		}
+	},
+	methods: {
+		handleName(v) {
+			this.name = v
+			this.sendData()
+		},
+		handleURL(v) {
+			this.url = v
+			this.sendData()
+		},
+		sendData() {
+			this.$emit({
+				name: String(this.name),
+				url: String(this.url)
+			})
+		}
+	}
+}

--- a/pages/posts/downloadlist.js
+++ b/pages/posts/downloadlist.js
@@ -1,0 +1,135 @@
+const DownloadField = () => import("./downloadfield.js")
+
+export default {
+	name: 'download-list',
+	props: {
+		value: {
+			type: Object,
+			required: true
+		},
+		rulesName: {
+			type: Array,
+			required: true
+		},
+		rulesURL: {
+			type: Array,
+			required: true
+		}
+	},
+	components: {
+		DownloadField
+	},
+	template: `
+	<div v-bind="$attrs">
+		<div v-for="(_, g_i) in content" :key="'download-group-' + g_i">
+			<v-row dense class="align-center">
+				<v-col><v-text-field class="mb-0"
+					v-model="content[g_i].name"
+					:label="$root.lang('posts.form.downloads.group.label')"
+					:placeholder="$root.lang('posts.form.downloads.group.placeholder')"
+					:hint="$root.lang('posts.form.downloads.group.hint')"
+					:rules="rulesName"
+				/></v-col>
+				<v-col class="flex-grow-0 flex-shrink-0">
+					<v-icon color="error" @click="() => removeGroup(g_i)">mdi-close</v-icon>
+				</v-col>
+			</v-row>
+			<v-row dense class="align-top">
+				<v-col class="flex-grow-0 flex-shrink-0">
+					<v-btn small @click="() => addDownload(g_i)">
+						{{ $root.lang('global.btn.add_download') }}
+						<v-icon color="white lighten-1">mdi-plus</v-icon>
+					</v-btn>
+				</v-col>
+				<v-col>
+					<v-row dense class="align-center" 
+						v-for="(_,l_i) in content[g_i].list"
+						:key="'download-list-' + g_i + '-' + l_i">
+						<v-col><DownloadField
+							v-model="content[g_i].list[l_i]"
+							:rulesName="rulesName"
+							:rulesURL="rulesURL"
+						/></v-col>
+						<v-col class="flex-grow-0 flex-shrink-0">
+							<v-icon class="mb-4" color="error" @click="() => removeDownload(g_i, l_i)">mdi-close</v-icon>
+						</v-col>
+					</v-row>
+				</v-col>
+			</v-row>
+		</div>
+		<div>
+			<v-btn block @click="addGroup">
+				{{ $root.lang('global.btn.add_group') }}
+				<v-icon color="white lighten-1">mdi-plus</v-icon>
+			</v-btn>
+		</div>
+	</div>`,
+	data() {
+		return {
+			content: this.mapValue(this.value)
+		}
+	},
+	watch: {
+		value: {
+			handler: function (n, o) {
+				if (JSON.stringify(n) === JSON.stringify(o)) return;
+				this.content = this.mapValue(this.value)
+			},
+			deep: true,
+			immediate: true
+		},
+		content: {
+			handler: function () {
+				this.$emit("input", this.unMapValue(this.content))
+			},
+			deep: true
+		}
+	},
+	methods: {
+		mapValue(v) {
+			if (!v) return []
+			return Object.entries(JSON.parse(JSON.stringify(v)))
+				.map(([key, value]) => ({
+					name: key,
+					list: value
+				}))
+		},
+		unMapValue(v) {
+			if (!v) return {}
+			const res = v.reduce((acc, cur) => ({
+				...acc,
+				[cur.name]: cur.list
+			}), {})
+			console.log(res)
+			return res
+		},
+		addGroup() {
+			let copy = JSON.parse(JSON.stringify(this.content))
+			copy.push({
+				name: "",
+				list: []
+			})
+			Vue.set(this, "content", copy)
+		},
+		removeGroup(groupIndex) {
+			let copy = JSON.parse(JSON.stringify(this.content))
+			copy.splice(groupIndex, 1)
+			Vue.set(this, "content", copy)
+		},
+		addDownload(groupIndex) {
+			let copy = JSON.parse(JSON.stringify(
+				this.content[groupIndex].list
+			))
+			copy.push({
+				name: "",
+				url: ""
+			})
+			Vue.set(this.content[groupIndex], "list", copy)
+		},
+		removeDownload(groupIndex, listIndex) {
+			let copy = JSON.parse(JSON.stringify(this.content[groupIndex].list))
+			copy.splice(listIndex, 1)
+			Vue.set(this.content[groupIndex], "list", copy)
+		},
+	}
+}

--- a/pages/posts/edit.js
+++ b/pages/posts/edit.js
@@ -1,0 +1,63 @@
+const Form = () => import('./form.js')
+
+export default {
+  name: 'edit-post-form',
+  components: {
+    Form
+  },
+  template: `
+  <div class="container">
+    <h4 class="text-h4 py-4">{{ $root.lang('posts.form.title.edit') }} <span id="addon-id">#{{this.id}}</span></h4>
+    <Form
+	  class="pa-0"
+      ref="form"
+      :is-new="false"
+	  :incoming-data="loadedData"
+	  v-on:reset="handleReset"
+      v-on:submit="handleSubmit"
+     />
+  </div>
+  `,
+  data: function () {
+    return {
+      loadedData: undefined,
+      loading: true,
+      error: undefined
+    }
+  },
+  computed: {
+    id: function () {
+      return this.$route.params.id
+    }
+  },
+  methods: {
+    handleSubmit: function (data) {
+      delete data.id
+
+      axios.put(`${this.$root.apiURL}/posts/${this.id}`, data, this.$root.apiOptions)
+        .then(() => {
+          this.$root.showSnackBar('Saved', 'success')
+        })
+        .catch(err => {
+          this.$root.showSnackBar(err, 'error', 3000)
+        })
+    },
+    handleReset: function () {
+      if (this.loading) return
+      this.$refs.form.setFormData(this.loadedData)
+    }
+  },
+  created: function () {
+    axios.get(`${this.$root.apiURL}/posts/${this.id}`, this.$root.apiOptions)
+      .then(res => {
+        this.loadedData = res.data
+      })
+      .catch(err => {
+        this.$root.showSnackBar(err, 'error', 3000)
+        this.error = err
+      })
+      .finally(() => {
+        this.loading = false
+      })
+  }
+}

--- a/pages/posts/form.js
+++ b/pages/posts/form.js
@@ -1,0 +1,415 @@
+/* global Vue, axios, marked */
+
+const FullscreenPreview = () => import('../addon/fullscreen-preview.js')
+const DateField = () => import('./datefield.js')
+const DownloadList = () => import('./downloadlist.js')
+
+export default {
+  name: 'post-form',
+  props: {
+    isNew: {
+      type: Boolean,
+      required: false,
+      default: () => false
+    },
+    incomingData: {
+      required: true
+    }
+  },
+  components: {
+    'fullscreen-preview': FullscreenPreview,
+    DateField,
+    DownloadList
+  },
+  template: `
+  <v-container>
+    <fullscreen-preview
+      v-if="!loading"
+      ref="headerPreview"
+      :src="submittedForm.headerImg"
+    />
+
+    <div class="text-center" v-if="loading && !isNew">
+      <h2 v-text="$root.lang('posts.form.title.loading_post')" class="mb-3"></h2>
+      <v-progress-circular
+        :size="70"
+        :width="7"
+        color="blue"
+        indeterminate
+      ></v-progress-circular>
+    </div>
+
+    <v-list v-if="!loading" :class="['main-container', 'my-2', {'mx-n3': !$vuetify.breakpoint.mdAndUp }]" :rounded="$vuetify.breakpoint.mdAndUp" two-line>
+      <v-form lazy-validation v-model="validForm" ref="form" style="padding: 0 6px">
+
+        <div class="container">
+          <div>
+            <v-btn class="float-right" prepend-icon="mdi-refresh" v-on:click="askReset">
+              <v-icon left>mdi-refresh</v-icon>
+              {{ $root.lang('posts.form.buttons.reset') }}
+            </v-btn>
+            <div class="text-h5 mb-4">{{ $root.lang('posts.form.title.general') }}</div>
+          </div>
+          <div class="row">
+            <!-- LEFT PART : INPUT -->
+            <div class="col pb-0">              
+              <v-text-field
+                required
+                clearable
+                v-model="submittedForm.title"
+                :rules="form.title.rules"
+                :label="$root.lang('posts.form.title.label')"
+                :hint="$root.lang('posts.form.title.hint')"
+              />
+
+              <v-text-field
+                required
+                clearable
+                v-model="submittedForm.permalink"
+                :label="$root.lang('posts.form.permalink.label')"
+                :hint="$root.lang('posts.form.permalink.hint')"
+              />
+
+              <v-text-field
+                required
+                clearable
+                v-model="submittedForm.headerImg"
+                :rules="form.headerImg.rules"
+                :label="$root.lang('posts.form.headerImg.label')"
+                :hint="$root.lang('posts.form.headerImg.hint')"
+              />
+            </div>
+
+            <!-- RIGHT PART: HEADER IMAGE PREVIEW -->
+            <div class="col-12 col-sm-3 d-flex px-0 pt-0 align-center" v-if="hasHeader">
+              <div class="col">
+                <div style="position: relative">
+                  <v-img
+                    @click.stop="(e) => $refs.headerPreview.open()"
+                    style="border-radius: 10px"
+                    :aspect-ratio="16/9"
+                    :src="submittedForm.headerImg"
+                  />
+                  <v-card class="ma-2" rounded style="display: inline-block; position: absolute; right: 0; top: 0;">
+                    <v-icon small class="ma-1" @click.stop="(e) => $refs.headerPreview.open()">
+                      mdi-fullscreen
+                    </v-icon><v-icon small class="ma-1" @click="submittedForm.headerImg = ''">
+                      mdi-delete
+                    </v-icon>
+                  </v-card>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="text-h5 mb-4">{{ $root.lang('posts.form.description.title') }}</div>
+
+          <v-textarea
+            clearable
+            v-model="submittedForm.description"
+            rows="10"
+            :label="$root.lang('posts.form.description.label')"
+            :hint="$root.lang('posts.form.description.hint')"
+          />
+
+          <!-- Description preview -->
+          <v-expansion-panels :value="0" flat class="dense my-4"
+            v-if="submittedForm.description && submittedForm.description.length > 0"
+          ><v-expansion-panel>
+            <v-expansion-panel-header>{{ $root.lang('posts.form.description.render') }}</v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <v-container
+                id="description-preview"
+                class="markdown pa-0 bg-transparent"
+                v-html="$root.compiledMarkdown(submittedForm.description)"
+              />
+            </v-expansion-panel-content>
+          </v-expansion-panel></v-expansion-panels>
+
+          <div class="text-h5 mb-4 mt-4">{{ $root.lang('posts.form.details.title') }}</div>
+
+          <div class="container">
+            <v-row class="align-center">
+                <div class="col-12 col-md-6">
+                  <v-checkbox
+                    v-model="submittedForm.published"
+                    :label="$root.lang('posts.form.published.label')"
+                    color="primary"
+                  />
+                </div>
+                <div class="col-12 col-md-6">
+                  <DateField
+                    class="mb-0"
+                    required
+                    v-model="submittedForm.date"
+                    :invalid-message="$root.lang('posts.form.date.invalid')"
+                    :label="$root.lang('posts.form.date.label')"
+                    :hint="$root.lang('posts.form.date.hint')"
+                  />
+                </div>
+            </v-row>
+          </div>
+
+          <div class="text-h5 mb-4">{{ $root.lang('posts.form.changelog.title') }}</div>
+
+          <v-textarea
+            clearable
+            v-model="changelogArea"
+            rows="20"
+            :label="$root.lang('posts.form.changelog.label')"
+            :hint="$root.lang('posts.form.changelog.hint')"
+            @change="handleChangelog"
+            spellcheck="false"
+            :rules="changelogRules"
+            class="mb-0 small-textarea"
+          />
+
+          <v-expansion-panels flat class="dense my-4"><v-expansion-panel>
+            <v-expansion-panel-header>{{ $root.lang('posts.form.changelog.render') }}</v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <v-container
+                id="description-preview"
+                class="markdown pa-0 bg-transparent json"
+                >
+                <pre class="pa-2">{{ JSON.stringify(submittedForm.changelog, null, 2) }}</pre>
+              </v-container>
+            </v-expansion-panel-content>
+          </v-expansion-panel></v-expansion-panels>
+          
+          <div class="text-h5 mt-0 mb-4">{{ $root.lang('addons.downloads.title') }}</div>
+
+          <DownloadList
+            v-model="submittedForm.downloads"
+            :rulesName="downloadTitleRules"
+            :rulesURL="downloadLinkRules"
+          />
+
+          <div class="text-center mt-4">
+            <v-btn smaall :disabled="!validForm" @click="() => onSubmit(false)" color="primary">
+              {{ $root.lang('global.btn.submit') }}
+            </v-btn>
+          </div>
+		    </div>
+      </v-form>
+    </v-list>
+  </v-container>
+  `,
+  data() {
+    return {
+      loading: true,
+      changelogArea: "",
+      form: {
+        headerImg: {
+          rules: [u => this.validURL(u) || this.$root.lang().addons.downloads.link.rule]
+        },
+        description: {
+          rules: [desc => !!desc || this.$root.lang('addons.general.description.rules.description_required')]
+        },
+        title: {
+          rules: [name => !!name || this.$root.lang('addons.general.name.rules.name_required')]
+        }
+      },
+      submittedForm: undefined,
+      downloadTitleRules: [
+        u => !!u || this.$root.lang().addons.downloads.name.rules.name_required,
+        u => u.trim() !== '' || this.$root.lang().addons.downloads.name.rules.name_cannot_be_empty
+      ],
+      downloadLinkRules: [u => this.validURL(u) || this.$root.lang().addons.downloads.link.rule],
+      validForm: false,
+      changelogRules: [u => this.validateChangelog(u)]
+    }
+  },
+  watch: {
+    incomingData: {
+      handler: function (n) {
+        if (!n) return
+        this.setFormData(n)
+      },
+      deep: true,
+      immediate: true
+    }
+  },
+  computed: {
+    hasHeader: function () {
+      return !!(this.submittedForm?.headerImg)
+    },
+    header: function () {
+      return this.addonNew ?
+        (this.headerValidating == false && this.headerValid && this.submittedForm.headerFile ?
+          URL.createObjectURL(this.submittedForm.headerFile) : undefined) :
+        (this.headerSource ? this.headerSource : undefined)
+    },
+    headerValidSentence: function () {
+      if (this.headerValidating) {
+        return "Header being verified..."
+      } else if (this.headerValid) {
+        return true
+      }
+
+      return this.headerError
+    },
+    headerRules: function () {
+      if (!this.addonNew) return []
+      return [...this.form.files.header.rules, this.headerValidSentence]
+    }
+  },
+  methods: {
+    askReset: function () {
+      this.$emit('reset')
+    },
+    setFormData: function (data) {
+      const parsed = JSON.parse(JSON.stringify(data))
+      this.submittedForm = parsed
+      this.setChangelog(parsed ? (parsed.changelog || '') : '')
+
+      if (this.$refs.form)
+        this.$refs.form.validate()
+      this.loading = false
+    },
+    setChangelog: function (v) {
+      this.changelogArea = this.parseChangelog(v, 0)
+    },
+    parseChangelog: function (obj, index = 0) {
+      const NEWLINE = '\n';
+      const spaces = Array(index * 2).fill(' ').join('');
+      if (Array.isArray(obj)) {
+        if (obj.length === 0) return NEWLINE;
+        return obj.map(s => this.parseChangelog(s, index)).join(NEWLINE);
+      }
+      else if (typeof (obj) === 'object') {
+        return Object.entries(obj).map(([key, values]) => (
+          `${spaces}- ${key}:\n${this.parseChangelog(values, index + 1)}`
+        )).join(NEWLINE)
+      }
+      else if (typeof (obj) === 'string') {
+        return `${spaces}- ${obj}`;
+      }
+
+      return NEWLINE;
+    },
+    onSubmit: function () {
+      const valid = this.$refs.form.validate()
+      if (!valid) return
+
+      this.$emit('submit', this.submittedForm)
+    },
+    validateRatio: function (ctx) {
+      const ratio = (ctx.width / ctx.height).toFixed(2) == 1.78
+      if (!ratio) throw new Error(this.$root.lang().addons.images.header.rules.image_ratio)
+    },
+    validURL: function (str) {
+      const pattern = new RegExp('^(https?:\\/\\/)?' + // protocol
+        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
+        '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
+        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
+        '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
+        '(\\#[-a-z\\d_]*)?$', 'i') // fragment locator
+      return !!pattern.test(str)
+    },
+    verifyImage: function (file, validateImage) {
+      if (validateImage === undefined) validateImage = this.validateRatio
+
+      return new Promise((resolve, reject) => {
+        // start reader
+        const reader = new FileReader()
+
+        reader.onload = function (e) {
+          const image = new Image()
+          image.src = e.target.result
+          image.onload = function () {
+            try {
+              validateImage(this)
+              resolve()
+            } catch (error) {
+              reject(error)
+            }
+          }
+          image.onerror = function (error) {
+            reject(e)
+          }
+        }
+        reader.onerror = function (error) {
+          reject(e)
+        }
+
+        // set file to be readt
+        reader.readAsDataURL(file)
+      })
+    },
+    unmapChangelog: function (val) {
+      let error // = undefined
+      let res // = undefined
+
+      let data = val.split('\n').map(s => {
+        const ends_with_colon = s.trim().endsWith(':')
+
+        if (!ends_with_colon) {
+          const first_index_dash = s.indexOf("-");
+          if (first_index_dash !== -1) {
+            // add " and escape []
+            s = s.substring(0, first_index_dash) + s.substring(first_index_dash).replace(/(-\s?)/, '$1"') + '"'
+          }
+        }
+        return s
+      }).join('\n')
+
+      try {
+        res = jsyaml.load(data)
+        if (!res) error = new Error("Failed to parse YAML")
+      } catch (err) {
+        error = err
+      }
+
+      // transform array of object as object with keys
+      res = this.objectArrayToObject(res)
+
+      return [error, res]
+    },
+    objectArrayToObject: function (val) {
+      let isObjectArray = Array.isArray(val) && val.reduce((acc, cur) => acc && typeof (cur) === 'object', true)
+      if (isObjectArray) {
+        return val.reduce((acc, cur) => {
+          let res = acc
+
+          Object.entries(cur).forEach(([key, v]) => {
+            res[key] = this.objectArrayToObject(v)
+          })
+
+          return acc
+        }, {})
+      } else if (Array.isArray(val)) {
+        return val.map(v => this.objectArrayToObject(v))
+      } else {
+        return val
+      }
+    },
+    validateChangelog: function (val) {
+      const lines = val.split('\n').map(s => s.trim())
+      let good = true
+      let i = 0
+      while (i < lines.length && good) {
+        good = lines[i].startsWith('- ')
+        i++
+      }
+
+      if (good) good = !this.unmapChangelog(val)[0]
+
+      if (!good)
+        return this.$root.lang("posts.form.changelog.invalid")
+
+      return true
+    },
+    handleChangelog: function (v) {
+      const [err, res] = this.unmapChangelog(v)
+
+      if (err) {
+        this.$root.showSnackBar(err, 'error')
+        return
+      }
+
+      this.submittedForm.changelog = res
+
+      return
+    }
+  }
+}

--- a/pages/posts/list.js
+++ b/pages/posts/list.js
@@ -1,0 +1,185 @@
+/* global axios */
+
+const Confirm = () => import('./confirm.js')
+
+export default {
+  name: 'posts-page',
+  components: {
+    Confirm
+  },
+  template: `
+  <v-container>
+    <div>
+      <v-row dense class="align-center py-4">
+        <v-col cols="12" class="col-sm"><div class="text-h4">
+        {{ $root.lang("posts.titles.list") }}
+        </div></v-col>
+        <v-col class="flex-grow-0 flex-shrink-0"><v-btn
+          color="primary"
+          href="/#/posts/new"
+        >
+          {{ $root.lang("posts.titles.new") }}
+          <v-icon
+            right
+          >
+            mdi-text-box-plus
+          </v-icon>
+        </v-btn></v-col>
+      </v-row>
+      <v-progress-circular
+        v-if="loading"
+        indeterminate
+      />
+    </div>
+
+    <div v-if="loading == false && data.length == 0">
+      {{ $root.lang().global.no_results }}
+    </div>
+    <div v-else class="my-2 text-h5">
+      <v-row>
+        <v-col 
+          :cols="$vuetify.breakpoint.mdAndUp ? 4 : ($vuetify.breakpoint.smAndUp ? 6 : 12)" 
+          v-for="post in sortedData"
+          style="align-items: stretch; display: flex;"
+        >
+          <v-card style="background-color: rgba(255,255,255,.05); width: 100%; display: flex; flex-direction: column">
+            <div>
+              <v-img
+                style="border-radius: 5px"
+                :src="post.headerImg ? post.headerImg : 'https://database.faithfulpack.net/images/branding/backgrounds/forest.png'"
+                :aspect-ratio="16/9" v-on:error="() => {failed[post.id] = true; $forceUpdate(); return false }">
+                <template v-slot:placeholder>
+                  <v-row
+                    class="fill-height ma-0"
+                    align="center"
+                    justify="center"
+                    style="background-color: rgba(255,255,255, 0.1);"
+                  >
+                    <v-icon
+                      v-if="failed[post.id]"
+                      x-large>mdi-image-off</v-icon>
+                    <v-progress-circular
+                      v-else
+                      indeterminate
+                      color="grey lighten-5"
+                    />
+                  </v-row>
+                </template>
+              </v-img>
+            </div>
+            <v-card-title v-text="post.title" style="word-break: break-word" />
+            <v-card-subtitle class="text-truncate" v-text="decodeURI(post.permalink)" :title="decodeURI(post.permalink)" />
+            <v-card-text style="flex-grow: 1">
+              <v-badge
+                dot
+                inline
+                :color="(post.published === true || post.published === 'true') ? 'green' : 'red'"
+              />
+              {{ $root.lang('posts.status.' + ((post.published === true || post.published === 'true') ? 'published' : 'unpublished')) }}
+              <v-btn
+                v-if="post.published === true || post.published === 'true'"
+                color="blue"
+                :href="'https://www.faithfulpack.net' + post.permalink"
+                target="_blank"
+                icon
+                small
+              >
+                <v-icon small>mdi-open-in-new</v-icon>
+              </v-btn>
+            </v-card-text>
+
+            <v-card-actions style="justify-content: flex-end;">
+              <v-btn
+                text
+                :href="'/#/posts/edit/' + post.id"
+              >
+                {{ $root.lang().global.btn.edit }}
+              </v-btn>
+              <v-btn
+                color="red"
+                text
+                @click="askConfirm(post.id, post.headerImg)"
+              >
+                {{ $root.lang().global.btn.delete }}
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+              
+        </v-col>
+      </v-row>
+    </div>
+
+    <Confirm
+      ref="confirm"
+      :data="confirmData"
+      :title="$root.lang('posts.confirm.title')"
+      :message="confirmMessage"
+      v-on:cancel="() => {}"
+      v-on:submit="deletePost"
+    />
+  </v-container>
+  `,
+  data() {
+    return {
+      data: {},
+      confirmData: undefined,
+      confirmUrl: undefined,
+      loading: true,
+      failed: {},
+      timestamp: new Date().getTime()
+    }
+  },
+  computed: {
+    sortedData: function () {
+      return Object.values(this.data).sort(this.sortDates)
+    },
+    confirmMessage: function () {
+      return this.$root.lang('posts.confirm.message')
+        + (this.confirmUrl ? `<a href="${this.confirmUrl}" target="_blank">${this.confirmUrl}</a>` : '')
+    }
+  },
+  methods: {
+    askConfirm: function (id, url) {
+      this.confirmUrl = url
+      console.log(this.$refs, this.$refs.confirm)
+      this.$refs.confirm.openDialog(id)
+    },
+    deletePost: function (id) {
+      axios.delete(`${this.$root.apiURL}/posts/${id}`, this.$root.apiOptions)
+        .then(() => {
+          this.$root.showSnackBar(this.$root.lang('global.ends_success'), 'success')
+          this.loadData()
+        })
+        .catch(err => this.$root.showSnackBar(err, 'error'))
+    },
+    loadData: function () {
+      this.loading = true
+      axios
+        .get(`${this.$root.apiURL}/posts/raw`, this.$root.apiOptions)
+        .then(res => {
+          this.data = res.data
+          this.loading = false
+          this.$forceUpdate()
+        })
+        .catch(function (err) {
+          console.error(err)
+        })
+    },
+    parseDate: function (d) {
+      const parts = d.split('-')
+      return new Date(`${parts[2]}-${parts[1]}-${parts[0]}`)
+    },
+    sortDates: function (a, b) {
+      const a_date = this.parseDate(a.date)
+      const b_date = this.parseDate(b.date)
+      return b_date.getTime() - a_date.getTime()
+    },
+    update: function () {
+      this.loadData()
+      this.$forceUpdate()
+    }
+  },
+  mounted() {
+    this.loadData()
+  }
+}

--- a/pages/posts/new.js
+++ b/pages/posts/new.js
@@ -1,0 +1,57 @@
+const Form = () => import('./form.js')
+
+export default {
+  name: 'new-addon-form',
+  components: {
+    'addon-form': Form
+  },
+  template: `
+  <div class="container">
+    <h4 class="text-h4 py-4">{{ $root.lang().addons.titles.submit }} </h4>
+    <addon-form
+      class="pa-0"
+      ref="form"
+      :is-new="false"
+      :incoming-data="loadedData"
+      v-on:reset="handleReset"
+      v-on:submit="handleSubmit"
+    />
+  </div>
+  `,
+  data: function () {
+    return {
+      loadedData: undefined,
+      isMounted: false
+    }
+  },
+  methods: {
+    emptyData: function () {
+      return {
+        title: "",
+        permalink: "",
+        date: moment(new Date()).format("DD-MM-YYYY").toString(),
+        headerImg: "",
+        description: "",
+        published: false,
+        downloads: {},
+        changelog: {}
+      }
+    },
+    handleReset: function () {
+      this.loadedData = this.emptyData()
+    },
+    handleSubmit: function () {
+      axios.post(`${this.$root.apiURL}/posts/`, data, this.$root.apiOptions)
+        .then(() => {
+          this.$root.showSnackBar('Saved', 'success')
+          this.$router.push('/posts/list')
+        })
+        .catch(err => {
+          this.$root.showSnackBar(err, 'error', 3000)
+        })
+    }
+  },
+  created: function () {
+    this.loadedData = this.emptyData()
+  }
+}

--- a/resources/css/webapp.css
+++ b/resources/css/webapp.css
@@ -480,6 +480,7 @@ blockquote {
   font-size: 0.8em;
   padding-bottom: 2px;
 }
+.markdown > pre,
 .markdown > p,
 .markdown > blockquote > p,
 .markdown > * > li,
@@ -491,6 +492,16 @@ blockquote {
   margin-left: 7.5px;
   border-left: 2.5px solid rgba(255, 255, 255, 0.3);
   padding-left: 5px;
+}
+
+.markdown.json {
+  max-height: 600px;
+  overflow: auto;
+}
+
+.small-textarea, .small-textarea textarea {
+  font-size: 0.894em;
+  line-height: 1.1;
 }
 
 pre {
@@ -716,9 +727,22 @@ code {
   cursor: pointer;
 }
 
-#addon-description-preview,
-#addon-description-preview > p {
-  word-break: break-all;
+.dense .v-expansion-panel--active > .v-expansion-panel-header {
+  min-height: 48px;
+}
+
+#description-preview {
+  background-color: rgba(0, 0, 0, 0.2);
+  border-radius: 5px;
+  text-align: justify;
+}
+
+#description-preview.bg-transparent {
+  background: transparent;
+}
+
+#description-preview > *:last-child {
+  margin-bottom: 0;
 }
 
 .list-item-inline {

--- a/resources/strings/en_US.js
+++ b/resources/strings/en_US.js
@@ -52,6 +52,13 @@ export default {
           upload: 'upload'
         }
       },
+      posts: {
+        title: 'Posts',
+        subtabs: {
+          list: 'List',
+          new: 'New'
+        }
+      },
       modding: {
         title: 'modding',
         subtabs: {
@@ -350,6 +357,25 @@ export default {
       approved: 'Approved',
       denied: 'Denied',
       pending: 'Pending'
+    }
+  },
+  posts: {
+    titles: {
+      list: "Article list",
+      new: "Write a new article",
+    },
+    status: {
+      published: "Published",
+      unpublished: "Unpublished"
+    },
+    confirm: {
+      title: "Are you sure you want to delete this post?",
+      message: "No for real, do you want this? There is no other save. You will still have to erase the header image: "
+    },
+    form: {
+      title: {
+        loading_post: "Loading post..."
+      }
     }
   },
   statistics: {

--- a/resources/strings/fr_FR.js
+++ b/resources/strings/fr_FR.js
@@ -54,6 +54,13 @@ export default {
           upload: 'upload'
         }
       },
+      posts: {
+        title: 'Posts',
+        subtabs: {
+          list: 'Liste',
+          new: 'Nouveau'
+        }
+      },
       modding: {
         title: 'modding',
         subtabs: {

--- a/webapp.js
+++ b/webapp.js
@@ -211,7 +211,7 @@ const ALL_TABS = [
         { path: '/textures/:type?/:name*', component: TexturePage }
       ]
     }, {
-      enabled: true, icon: 'mdi-settings', label: 'settings',
+      enabled: true, icon: 'mdi-wrench', label: 'settings',
       routes: [{ path: '/settings', component: SettingsPage }]
     }, {
       enabled: false, icon: 'mdi-pipe-wrench', label: 'mods',
@@ -444,7 +444,7 @@ axios.get('./resources/settings.json')
             let found = false
 
             const tab = this.tabs[i]
-            tab.labelText = this.lang().global.tabs[this.tabs[i].label]?.title
+            tab.labelText = this.lang(`global.tabs.${this.tabs[i].label}.title`)
 
             if (this.tabs[i].roles) {
               this.tabs[i].roles.forEach(role => {
@@ -455,7 +455,7 @@ axios.get('./resources/settings.json')
             if (found) {
               res.push(this.tabs[i])
               this.tabs[i].subtabs.forEach(subtab => {
-                subtab.labelText = this.lang().global.tabs[this.tabs[i].label]?.subtabs[subtab.label]
+                subtab.labelText = this.lang(`global.tabs.${this.tabs[i].label}.subtabs.${subtab.label}`)
               })
             }
           }
@@ -574,7 +574,7 @@ axios.get('./resources/settings.json')
           }
 
           // Shall send string to be chained with other string operations
-          return String(response) // enforce string to ensure string methods used after
+          return String(response || path) // enforce string to ensure string methods used after
         },
         showSnackBar: function (err, color = '#222', timeout = 4000) {
           let message = ''

--- a/webapp.js
+++ b/webapp.js
@@ -519,7 +519,6 @@ axios.get('./resources/settings.json')
           import(lang.file)
             .then(r => {
               r = r.default
-              console.log(r)
               this.langs[lang.lang] = Object.merge({}, enUS, r)
               // we need to wait for this.langs to be updated
               this.$nextTick(() => {
@@ -702,11 +701,9 @@ axios.get('./resources/settings.json')
       mounted: function () {
         // watch color schemes for light and dark
         window.matchMedia("(prefers-color-scheme: dark)").onchange = (ev) => {
-          console.log(ev)
           if(ev.matches) this.onMediaChange(true)
         }
         window.matchMedia("(prefers-color-scheme: light)").onchange = (ev) => {
-          console.log(ev)
           if(ev.matches) this.onMediaChange(false)
         }
         window.addEventListener('resize', () => {

--- a/webapp.js
+++ b/webapp.js
@@ -614,7 +614,7 @@ axios.get('./resources/settings.json')
         },
         compiledMarkdown: function (markdown) {
           if (markdown === null || !markdown) return ''
-          return marked(markdown, { sanitize: true })
+          return DOMPurify.sanitize(marked.parse(markdown, { breaks: true, gfm: true }))
         },
         addToken(data) {
           data.token = this.user.access_token

--- a/webapp.js
+++ b/webapp.js
@@ -19,6 +19,9 @@ const GalleryPage = () => import('./pages/gallery/gallery.js')
 const SettingsPage = () => import('./pages/settings/settingsPage.js')
 const DashboardPage = () => import('./pages/dashboard/dashboard.js')
 const ReconnectPage = () => import('./pages/reconnect/reconnect.js')
+const ArticleNewPage = () => import('./pages/posts/new.js')
+const ArticleEditPage = () => import('./pages/posts/edit.js')
+const ArticleListPage = () => import('./pages/posts/list.js')
 
 window.colors = (await import('https://cdn.jsdelivr.net/npm/vuetify@2.6.4/lib/util/colors.min.js')).default
 window.colorToHex = function(color) {
@@ -190,6 +193,21 @@ const ALL_TABS = [
           window.location.href = 'https://translate.faithfulpack.net/';
         }
       }]
+    }],
+    roles: ['Administrator']
+  },
+  {
+    label: 'posts',
+    subtabs: [{
+      enabled: true, icon: 'mdi-text-box', label: 'list',
+      routes: [{ path: '/posts/list', component: ArticleListPage }]
+    },
+    {
+      enabled: true, icon: 'mdi-text-box-plus', label: 'new',
+      routes: [
+        { path: '/posts/new', component: ArticleNewPage },
+        { path: '/posts/edit/:id', component: ArticleEditPage }
+      ]
     }],
     roles: ['Administrator']
   },

--- a/webapp.js
+++ b/webapp.js
@@ -577,26 +577,47 @@ axios.get('./resources/settings.json')
           // Shall send string to be chained with other string operations
           return String(response) // enforce string to ensure string methods used after
         },
-        showSnackBar: function (message, color = '#222', timeout = 4000) {
+        showSnackBar: function (err, color = '#222', timeout = 4000) {
+          let message = ''
+          let submessage = ''
+
+          this.snackbar.message = ''
           this.snackbar.submessage = ''
-          if(typeof message === 'string') {
-            let newline = message.indexOf('\n')
+
+          if (typeof err === 'string') {
+            let newline = err.indexOf('\n')
             if(newline !== -1) {
-              this.snackbar.message = message.substring(0, newline) + ':'
-              this.snackbar.submessage = message.substring(newline+1)
+              message = err.substring(0, newline) + ':'
+              submessage = err.substring(newline + 1).replaceAll('\n', '<br>')
             } else {
-              this.snackbar.message = message
+              message = err
             }
           }
           else {
-            this.snackbar.message = message.message
+            // normal error
+            message = err.message
 
-            if (message.response && message.response.data) {
-              let submessage = message.response.data.error || message.response.data.message
-              this.snackbar.message += ':'
-              this.snackbar.submessage = submessage
+            // parse YAMLException
+            if (err.message && err.reason) {
+              message = err.reason
+              submessage = err.message
+            }
+            if (err.response && err.response.data) {
+              submessage = err.response.data.error || err.response.data.message
+              message += ':'
             }
           }
+
+          // remove duplicate lines
+          message = message.split('\n').filter(s => s.trim().length !== 0).join('\n')
+          submessage = submessage.split('\n').filter(s => s.trim().length !== 0).join('\n')
+
+          console.error(message)
+          if (submessage)
+            console.error(submessage)
+
+          this.snackbar.message = message.replace('\n', '<br>')
+          this.snackbar.submessage = submessage.replace('\n', '<br>')
 
           this.snackbar.color = color
           this.snackbar.timeout = timeout


### PR DESCRIPTION
I almost forgot I did this, it's full featured post editor.
It is just like the addons but for posts.

You have the form:
![image](https://github.com/Faithful-Resource-Pack/App/assets/18086786/0dfdfbc2-7a28-4732-b28a-f387b1da48e5)

You have the list with the items:
![image](https://github.com/Faithful-Resource-Pack/App/assets/18086786/5117bb08-6fba-4a1e-a805-37c5c8e3df78)

I strengthened some code by the way.

## Left to do
- [ ] All the translations, starting with english at least. You can fill the desired titles thanks to their id and by reading the commits.
- [ ] Maybe split in tabs the form? it's a very long form. Or just give the preview its tab just like GitHub does
- [x] The API side seems already done https://api.faithfulpack.net/docs/#/Posts 
- [ ] Update with newer articles not in db yet
- [ ] Implement the website side too I guess