### PR TITLE
Move author selection box up

### DIFF
--- a/pages/addon/addon-form.vue
+++ b/pages/addon/addon-form.vue
@@ -26,6 +26,7 @@
 					<!-- LEFT PART : INPUT -->
 					<div class="col pb-0">
 						<div class="text-h5">{{ $root.lang().addons.general.title }}</div>
+
 						<!-- Addon name -->
 						<v-text-field
 							required
@@ -35,6 +36,14 @@
 							:counter="form.name.counter.max"
 							:label="$root.lang().addons.general.name.label"
 							:hint="$root.lang().addons.general.name.hint"
+						/>
+
+						<!-- Addon authors selection -->
+						<user-select
+							:users="users"
+							v-model="submittedForm.authors"
+							:label="$root.lang().addons.general.authors.label"
+							:hint="$root.lang().addons.general.authors.hint"
 						/>
 
 						<div class="text-h5 mb-3" v-if="!$vuetify.breakpoint.smAndDown">
@@ -161,14 +170,6 @@
 					v-if="$root.isAdmin && !addonNew"
 					:label="$root.lang().addons.general.slug.label"
 					:hint="$root.lang().addons.general.slug.hint"
-				/>
-
-				<!-- Addon authors selection -->
-				<user-select
-					:users="users"
-					v-model="submittedForm.authors"
-					:label="$root.lang().addons.general.authors.label"
-					:hint="$root.lang().addons.general.authors.hint"
 				/>
 
 				<div class="text-h5">{{ $root.lang().addons.options.title }}</div>


### PR DESCRIPTION
This pull request is the last one of my organization related changes that aims to make the edit add-on form more consistent and organized. Merging this pull request will move the author selection box up to be under the add-on name rather than being in the details section.

Before:

![Screenshot showing the normal edit add-on form](https://github.com/user-attachments/assets/dac8b3a6-a2fb-4615-be84-1d8aa2a36677)

After:

![Screenshot showing the same thing but the authors selection box has been moved up to be under the add-on name](https://github.com/user-attachments/assets/27a0fbf2-56c9-44c7-bc25-aaec9b39f769)

Now it's time for you to review and decide.