### PR TITLE
Fix up add-on description preview

### DIFF
--- a/pages/addon/addon-form.vue
+++ b/pages/addon/addon-form.vue
@@ -147,7 +147,7 @@
 				<v-card
 					id="addon-description-preview"
 					v-if="submittedForm.description && submittedForm.description.length > 0"
-					class="markdown pa-3"
+					class="pa-3"
 					:elevation="0"
 					v-html="$root.compiledMarkdown(submittedForm.description)"
 				/>

--- a/resources/css/webapp.css
+++ b/resources/css/webapp.css
@@ -771,8 +771,16 @@ code {
 }
 
 #addon-description-preview,
-#addon-description-preview > p {
-	word-break: break-all;
+#addon-description-preview > pre {
+	white-space: inherit;
+}
+
+#addon-description-preview pre:not(:last-child) {
+	margin-bottom: 16px;
+}
+
+#addon-description-preview code {
+	box-decoration-break: clone;
 }
 
 .list-item-inline {


### PR DESCRIPTION
This pull request aims to fix the add-on description preview by removing the `.markdown` class assignment (which fixes the small font size issue without having to deal with complicated CSS styling), adding proper word wrapping and fixing inconsistent spacing with code blocks.

I'd appreciate a review before merging.

This is the second last pull request I will do relating to the add-on form. (The last one will be to fix the inconsistent spacing in general) ~~(To clear up some confusion, my previous pull request was the last one referring to **organization** related changes, which meant the last thing I will do to change the structure of the add-on form)~~