### PR TITLE
Overhaul the new texture modal

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ window.colorToHex = (color) => {
 		if (colorArr.length > 1) colorArr[1] = colorArr[1].replace("-", "");
 		return colors[colorArr[0]][colorArr.length > 1 ? colorArr[1] : "base"];
 	} catch (error) {
-		return "primary";
+		return "inherit";
 	}
 };
 
@@ -73,7 +73,6 @@ window.updatePageStyles = (page) => {
 
 	const pageId = page.$el.id;
 	const hex = colorToHex(page.pageColor);
-	console.log(pageId, hex);
 
 	page.pageStyles = `
 	<style>

--- a/index.js
+++ b/index.js
@@ -66,15 +66,16 @@ window.colorToHex = (color) => {
 	}
 };
 
-/** @param {Vue} cmp */
-window.updatePageStyles = (cmp) => {
-	if (!cmp.$el) return;
-	cmp.$el.id ||= cmp.name;
+/** @param {Vue} page */
+window.updatePageStyles = (page) => {
+	if (!page.$el) return;
+	page.$el.id ||= page.name;
 
-	const pageId = cmp.$el.id;
-	const hex = colorToHex(cmp.pageColor);
+	const pageId = page.$el.id;
+	const hex = colorToHex(page.pageColor);
+	console.log(pageId, hex);
 
-	cmp.pageStyles = `
+	page.pageStyles = `
 	<style>
 		html.theme--light,
 		html.theme--light .colored,
@@ -93,7 +94,7 @@ window.updatePageStyles = (cmp) => {
 		html.theme--dark .v-menu__content *,
 		html.theme--dark #${pageId},
 		html.theme--dark #${pageId} * {
-			scrollbar-color: ${hex} #000000bb;
+			scrollbar-color: ${hex} #000000bb !important;
 		}
 	</style>`;
 };

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ window.colorToHex = (color) => {
 		if (colorArr.length > 1) colorArr[1] = colorArr[1].replace("-", "");
 		return colors[colorArr[0]][colorArr.length > 1 ? colorArr[1] : "base"];
 	} catch (error) {
-		return "currentcolor";
+		return "primary";
 	}
 };
 

--- a/pages/components/fullscreen-modal.vue
+++ b/pages/components/fullscreen-modal.vue
@@ -3,6 +3,7 @@
 		v-model="modalOpened"
 		fullscreen
 		hide-overlay
+		content-class="colored"
 		transition="dialog-bottom-transition"
 		@keydown.esc="closeModal"
 	>

--- a/pages/components/fullscreen-modal.vue
+++ b/pages/components/fullscreen-modal.vue
@@ -6,6 +6,7 @@
 		transition="dialog-bottom-transition"
 		@keydown.esc="closeModal"
 	>
+		<div class="styles" v-html="pageStyles" />
 		<v-card>
 			<v-toolbar>
 				<v-btn icon @click.stop="closeModal">
@@ -40,16 +41,25 @@ export default {
 			required: false,
 			default: false,
 		},
+		pageColor: {
+			type: String,
+			required: false,
+			default: "primary",
+		},
 	},
 	data() {
 		return {
 			modalOpened: false,
+			pageStyles: "",
 		};
 	},
 	methods: {
 		closeModal() {
 			this.$emit("close");
 		},
+	},
+	mounted() {
+		updatePageStyles(this);
 	},
 	watch: {
 		value: {

--- a/pages/texture/new-texture-modal.vue
+++ b/pages/texture/new-texture-modal.vue
@@ -1,7 +1,7 @@
 <template>
 	<fullscreen-modal
 		v-model="modalOpened"
-		:title="$root.lang().database.titles.add_texture"
+		:title="$root.lang().database.labels.add_texture"
 		:pageColor="color"
 		@close="closeModal"
 	>

--- a/pages/texture/new-texture-modal.vue
+++ b/pages/texture/new-texture-modal.vue
@@ -7,7 +7,7 @@
 	>
 		<template #toolbar>
 			<v-btn icon @click="copyData"><v-icon>mdi-content-copy</v-icon></v-btn>
-			<v-btn icon @click="openJSONModal"><v-icon>mdi-content-paste</v-icon></v-btn>
+			<v-btn icon @click="openJSONModal"><v-icon>mdi-code-json</v-icon></v-btn>
 			<v-dialog v-model="jsonModalOpened" content-class="colored" max-width="800">
 				<v-card>
 					<h2 class="title text--secondary ma-2">

--- a/pages/texture/new-texture-modal.vue
+++ b/pages/texture/new-texture-modal.vue
@@ -309,6 +309,7 @@ export default {
 		},
 		summaryString(tex) {
 			const labels = this.$root.lang().database.labels;
+			// bit cleaner than using a ton of nested ternaries
 			let strBuilder = `${tex.uses.length} `;
 			strBuilder += tex.uses.length === 1 ? labels.use_singular : labels.use_plural;
 			const pathCount = tex.uses.reduce((acc, cur) => acc + cur.paths.length, 0);
@@ -386,7 +387,7 @@ export default {
 			try {
 				let data = JSON.parse(this.importJSON);
 				if (!data || !data.length) data = [emptyTexture()];
-				// make sure there's at least one use and one path to prevent form errors
+				// validate parsed data
 				const cleaned = data.map((tex) => {
 					tex.key = crypto.randomUUID();
 					tex.name ||= "";
@@ -396,6 +397,12 @@ export default {
 						use.key = crypto.randomUUID();
 						use.edition ||= "";
 						if (!use.paths || !use.paths.length) use.paths = [emptyPath()];
+						use.paths = use.paths.map((path) => {
+							path.name ||= "";
+							path.versions ||= [];
+							path.mcmeta ||= false;
+							return path;
+						});
 						return use;
 					});
 					return tex;

--- a/pages/texture/new-texture-modal.vue
+++ b/pages/texture/new-texture-modal.vue
@@ -17,12 +17,11 @@
 					</h2>
 					<prism-editor
 						class="my-editor"
-						style="height: 75%"
 						v-model="importJSON"
 						:highlight="highlighter"
 						line-numbers
 					/>
-					<v-btn block @click="parseJSON" :color="color">
+					<v-btn block @click="parseJSON" :color="color" class="white--text">
 						{{ $root.lang().database.labels.parse_json }}
 					</v-btn>
 				</div>
@@ -194,7 +193,7 @@
 					</v-list>
 					<v-divider class="ma-5" />
 					<v-row no-gutters>
-						<v-col cols="12" lg="6">
+						<v-col cols="12" sm="6">
 							<v-checkbox
 								:color="color"
 								v-model="clearOnSave"
@@ -202,12 +201,12 @@
 								:label="$root.lang('database.labels.clear_on_save')"
 							/>
 						</v-col>
-						<v-col cols="12" lg="3">
+						<v-col cols="12" sm="3">
 							<v-btn class="px-1" color="red darken-1" text @click="resetModal">
 								{{ $root.lang().global.btn.discard }}
 							</v-btn>
 						</v-col>
-						<v-col cols="12" lg="3">
+						<v-col cols="12" sm="3">
 							<v-btn class="px-1" color="darken-1" text @click="send">
 								{{ $root.lang().global.btn.save }}
 							</v-btn>

--- a/pages/texture/new-texture-modal.vue
+++ b/pages/texture/new-texture-modal.vue
@@ -7,16 +7,14 @@
 	>
 		<template #toolbar>
 			<v-btn icon @click="copyData"><v-icon>mdi-content-copy</v-icon></v-btn>
-			<v-menu v-model="jsonModalOpened" :close-on-content-click="false">
-				<template #activator="{ on, attrs }">
-					<v-btn icon v-on="on" v-bind="attrs"><v-icon>mdi-content-paste</v-icon></v-btn>
-				</template>
-				<div class="texture-json-editor">
+			<v-btn icon @click="openJSONModal"><v-icon>mdi-content-paste</v-icon></v-btn>
+			<v-dialog v-model="jsonModalOpened" content-class="colored" max-width="800">
+				<v-card>
 					<h2 class="title text--secondary ma-2">
 						{{ $root.lang().database.subtitles.import_json_data }}
 					</h2>
 					<prism-editor
-						class="my-editor"
+						class="my-editor texture-json-editor"
 						v-model="importJSON"
 						:highlight="highlighter"
 						line-numbers
@@ -24,8 +22,8 @@
 					<v-btn block @click="parseJSON" :color="color" class="white--text">
 						{{ $root.lang().database.labels.parse_json }}
 					</v-btn>
-				</div>
-			</v-menu>
+				</v-card>
+			</v-dialog>
 		</template>
 		<div class="px-10 py-5">
 			<v-row>
@@ -381,6 +379,9 @@ export default {
 			texture.name ||= name;
 
 			texture.tags = sortTags([...texture.tags, getTagFromPath(path.name)].map(formatTag));
+		},
+		openJSONModal() {
+			this.jsonModalOpened = true;
 		},
 		parseJSON() {
 			try {

--- a/resources/css/webapp.css
+++ b/resources/css/webapp.css
@@ -1251,8 +1251,10 @@ body .texture-avatar {
 }
 
 .texture-json-editor {
-	width: 50vw;
-	height: 80vh;
-	display: flex;
-	flex-direction: column;
+	min-height: 20em;
+}
+
+.v-slide-group__prev--disabled {
+	/* fix weird left margin on mobile tabs */
+	display: none !important;
 }

--- a/resources/css/webapp.css
+++ b/resources/css/webapp.css
@@ -1253,4 +1253,6 @@ body .texture-avatar {
 .texture-json-editor {
 	width: 50vw;
 	height: 80vh;
+	display: flex;
+	flex-direction: column;
 }

--- a/resources/css/webapp.css
+++ b/resources/css/webapp.css
@@ -1244,3 +1244,13 @@ body .texture-avatar {
 	width: 100% !important;
 	height: 100% !important;
 }
+
+.v-timeline-item__dot,
+.v-timeline-item__inner-dot {
+	border-radius: 4px;
+}
+
+.texture-json-editor {
+	width: 50vw;
+	height: 80vh;
+}

--- a/resources/strings/en_US.js
+++ b/resources/strings/en_US.js
@@ -34,6 +34,7 @@ export default {
 			approve: "Approve",
 			archive: "Archive",
 			load_more: "Load More",
+			discard: "Discard",
 		},
 		tabs: {
 			general: {
@@ -153,6 +154,7 @@ export default {
 			paths: "Paths",
 		},
 		labels: {
+			copy_json_data: "Copied JSON data to clipboard",
 			anonymous: "Anonymous",
 			anonymous_explain:
 				"If checked, the user's name will be displayed as \"Anonymous\" and their skin won't show up. Can only be changed by managers!",
@@ -161,6 +163,7 @@ export default {
 			new_mc_version_path: "Clone an existing version as a template",
 			new_mc_version_name: "New version name",
 			nameless: "Nameless",
+			tagless: "No tags added",
 			add_textures_success: "Added texture(s) successfully",
 			add_version_success: "Added version successfully",
 			add_new_user: "Add new user",
@@ -174,6 +177,7 @@ export default {
 			ask_deletion: "Do you want to delete %s (%d)?",
 			ask_submission_deletion: "Do you want to delete submission information for %s (%d)?",
 			close_on_submit: "Close on submit",
+			clear_on_save: "Clear on save",
 			user_role: "User roles",
 			discord_id: "Discord ID",
 			pack_id: "Pack ID",
@@ -226,6 +230,10 @@ export default {
 				one_required: "At least one texture ID or an ID range is required",
 				incorrect_value: "Incorrect texture %value% ID or ID range",
 			},
+			use_singular: "Use",
+			use_plural: "Uses",
+			path_singular: "Path",
+			path_plural: "Paths",
 		},
 		hints: {
 			pack_id_creation: "A Pack ID can either be manually specified or automatically generated.",


### PR DESCRIPTION
Visual overhaul of the new texture modal to be less cluttered and more usable. Also added an export button so users can 
save texture drafts and have better debug logs.

Comparison:
<img width="1361" alt="Screen Shot 2024-09-15 at 1 05 07 PM" src="https://github.com/user-attachments/assets/c617cdf9-105a-4494-89c5-9c9f6de0b3ab">

<img width="1678" alt="Screen Shot 2024-09-15 at 1 05 27 PM" src="https://github.com/user-attachments/assets/7d960896-8c59-426c-a81c-05ba123137ce">

Closes #139 