### PR TITLE
Add animations for animated textures inside the gallery

### DIFF
--- a/pages/gallery/gallery-animation.vue
+++ b/pages/gallery/gallery-animation.vue
@@ -1,0 +1,156 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+interface AnimationFrame {
+	index: number;
+	time: number;
+}
+
+interface Animation {
+	frames?: (number | AnimationFrame)[];
+	frametime?: number;
+	interpolate?: boolean;
+}
+
+export default defineComponent({
+	name: 'AnimationCanvas',
+	props: {
+		src: { type: String, required: true },
+		mcmeta: { type: Object as () => { animation?: Animation }, default: () => ({ animation: {} }) },
+		isTiled: { type: Boolean, default: false },
+	},
+	data() {
+		return {
+			canvasRef: null as HTMLCanvasElement | null,
+			image: null as HTMLImageElement | null,
+			sprites: [] as AnimationFrame[],
+			frames: {} as Record<number, [AnimationFrame, number][]>,
+			currentTick: 1,
+			tickingRef: null as ReturnType<typeof setInterval> | null,
+		};
+	},
+	methods: {
+		loadImage() {
+			const img = new Image();
+			img.setAttribute('crossorigin', 'anonymous');
+			img.src = this.src;
+
+			img.onload = () => {
+				this.image = img;
+				this.tickingRef = setInterval(() => {}, 1000 / 20);
+			};
+
+			img.onerror = () => {
+				this.image = null;
+				if (this.tickingRef) {
+					clearInterval(this.tickingRef);
+					this.tickingRef = null;
+				}
+			};
+		},
+		calculateFrames() {
+			if (!this.image || !this.mcmeta) return;
+
+			const animation = this.mcmeta.animation ?? {};
+			const animationFrames: AnimationFrame[] = [];
+
+			if (animation.frames) {
+				for (const frame of animation.frames) {
+					if (typeof frame === 'object') {
+						animationFrames.push({ index: frame.index, time: Math.max(frame.time, 1) });
+					} else {
+						animationFrames.push({ index: frame, time: animation.frametime ?? 1 });
+					}
+				}
+			} else {
+				const framesCount = this.isTiled
+					? this.image.height / 2 / (this.image.width / 2)
+					: this.image.height / this.image.width;
+				for (let fi = 0; fi < framesCount; fi++) {
+					animationFrames.push({ index: fi, time: animation.frametime ?? 1 });
+				}
+			}
+
+			const framesToPlay: Record<number, [AnimationFrame, number][]> = {};
+			let ticks = 1;
+			animationFrames.forEach((frame, index) => {
+				for (let t = 1; t <= frame.time; t++) {
+					framesToPlay[ticks] = [[frame, 1]];
+
+					if (animation.interpolate) {
+						const nextFrame = animationFrames[index + 1] ?? animationFrames[0];
+						framesToPlay[ticks]?.push([nextFrame, t / nextFrame.time]);
+					}
+
+					ticks++;
+				}
+			});
+
+			this.sprites = animationFrames;
+			this.frames = framesToPlay;
+		},
+		updateCanvas() {
+			if (Object.keys(this.frames).length === 0) return;
+
+			setTimeout(() => {
+				let next = this.currentTick + 1;
+				if (this.frames[next] === undefined) next = 1;
+				this.currentTick = next;
+
+				this.updateCanvas();
+			}, 1000 / 20);
+		},
+		drawFrame() {
+			if (Object.keys(this.frames).length === 0) return;
+
+			const framesToDraw = this.frames[this.currentTick];
+			const canvas = this.$refs.canvasRef as HTMLCanvasElement;
+			const context = canvas?.getContext('2d');
+
+			if (!canvas || !context || !this.image || !framesToDraw) return;
+
+			canvas.style.width = '100%';
+			canvas.width = canvas.offsetWidth;
+			canvas.height = canvas.offsetWidth;
+
+			const padding = this.isTiled ? this.image.width / 4 : 0;
+			const width = this.isTiled ? this.image.width / 2 : this.image.width;
+
+			context.clearRect(0, 0, width, width);
+			context.globalAlpha = 1;
+			context.imageSmoothingEnabled = false;
+
+			for (const frame of framesToDraw) {
+				const [data, alpha] = frame;
+				context.globalAlpha = alpha;
+
+				context.drawImage(
+					this.image,
+					padding,
+					padding + (width * data.index) * (this.isTiled ? 2 : 1),
+					width,
+					width,
+					0,
+					0,
+					canvas.width,
+					canvas.width
+				);
+			}
+		},
+	},
+	watch: {
+		src: 'loadImage',
+		mcmeta: 'calculateFrames',
+		image: 'calculateFrames',
+		currentTick: 'drawFrame',
+		frames: 'updateCanvas',
+	},
+	mounted() {
+		this.loadImage();
+	},
+});
+</script>
+
+<template>
+	<canvas ref="canvasRef"></canvas>
+</template>

--- a/pages/gallery/gallery-animation.vue
+++ b/pages/gallery/gallery-animation.vue
@@ -28,6 +28,7 @@ export default defineComponent({
 			frames: {} as Record<number, [AnimationFrame, number][]>,
 			currentTick: 1,
 			tickingRef: null as ReturnType<typeof setInterval> | null,
+			updateCanvasTimeout:  null as ReturnType<typeof setTimeout> | null,
 		};
 	},
 	methods: {
@@ -93,7 +94,10 @@ export default defineComponent({
 		updateCanvas() {
 			if (Object.keys(this.frames).length === 0) return;
 
-			setTimeout(() => {
+			// make sure the canvas is updated at most 20 times per second (50ms)
+			if (this.updateCanvasTimeout) clearTimeout(this.updateCanvasTimeout);
+
+			this.updateCanvasTimeout = setTimeout(() => {
 				let next = this.currentTick + 1;
 				if (this.frames[next] === undefined) next = 1;
 				this.currentTick = next;
@@ -148,6 +152,11 @@ export default defineComponent({
 	},
 	mounted() {
 		this.loadImage();
+	},
+	beforeUnmount() {
+		// clear all intervals and timeouts to prevent memory leaks
+		if (this.tickingRef) clearInterval(this.tickingRef);
+		if (this.updateCanvasTimeout) clearTimeout(this.updateCanvasTimeout);
 	},
 });
 </script>

--- a/pages/gallery/gallery-animation.vue
+++ b/pages/gallery/gallery-animation.vue
@@ -107,10 +107,18 @@ export default {
 		},
 	},
 	watch: {
-		src: "loadImage",
-		mcmeta: "calculateFrames",
-		image: "calculateFrames",
-		frames: "updateCanvas",
+		src() {
+			return this.loadImage();
+		},
+		mcmeta() {
+			return this.calculateFrames();
+		},
+		image() {
+			return this.calculateFrames();
+		},
+		frames() {
+			return this.updateCanvas();
+		},
 		currentTick() {
 			if (Object.keys(this.frames).length === 0) return;
 

--- a/pages/gallery/gallery-animation.vue
+++ b/pages/gallery/gallery-animation.vue
@@ -17,6 +17,7 @@ export default defineComponent({
 	props: {
 		src: { type: String, required: true },
 		mcmeta: { type: Object as () => { animation?: Animation }, default: () => ({ animation: {} }) },
+		// Determine if the image is a tiled texture (used for flowing fluids which are 2x2 textures)
 		isTiled: { type: Boolean, default: false },
 	},
 	data() {

--- a/pages/gallery/gallery-animation.vue
+++ b/pages/gallery/gallery-animation.vue
@@ -3,18 +3,20 @@
 </template>
 
 <script lang="ts">
+interface Point {
+	/** left to right */
+	x: number;
+	/** top to bottom */
+	y: number;
+}
+
 interface Frame {
 	index: number;
 	frametime: number;
-
-	/** top left */
-	p0: { x: number; y: number };
-	/** top right */
-	p1: { x: number; y: number };
-	/** bottom right */
-	p2: { x: number; y: number };
-	/** bottom left */
-	p3: { x: number; y: number };
+	topLeft: Point;
+	topRight: Point;
+	bottomRight: Point;
+	bottomLeft: Point;
 }
 
 interface Animation {
@@ -119,17 +121,17 @@ export default {
 				// then we shift using the index to get the right frame
 				if (this.isTiled)
 					return {
-						p0: { x: width / 4, y: height / 4 + height * index },
-						p1: { x: width / 4 + width / 2, y: height / 4 + height * index },
-						p2: { x: width / 4 + width / 2, y: height / 4 + height / 2 + height * index },
-						p3: { x: width / 4, y: height / 4 + height / 2 + height * index },
+						topLeft: { x: width / 4, y: height / 4 + height * index },
+						topRight: { x: width / 4 + width / 2, y: height / 4 + height * index },
+						bottomRight: { x: width / 4 + width / 2, y: height / 4 + height / 2 + height * index },
+						bottomLeft: { x: width / 4, y: height / 4 + height / 2 + height * index },
 					};
 
 				return {
-					p0: { x: 0, y: height * index },
-					p1: { x: width, y: height * index },
-					p2: { x: width, y: height * (index + 1) },
-					p3: { x: 0, y: height * (index + 1) },
+					topLeft: { x: 0, y: height * index },
+					topRight: { x: width, y: height * index },
+					bottomRight: { x: width, y: height * (index + 1) },
+					bottomLeft: { x: 0, y: height * (index + 1) },
 				};
 			};
 
@@ -234,11 +236,11 @@ export default {
 					this.image,
 
 					// source x, source y
-					f.p0.x,
-					f.p0.y,
+					f.topLeft.x,
+					f.topLeft.y,
 					// source width, source height
-					f.p1.x - f.p0.x,
-					f.p3.y - f.p0.y,
+					f.topRight.x - f.topLeft.x,
+					f.bottomLeft.y - f.topLeft.y,
 
 					// dest x, dest y, dest width, dest height
 					0,

--- a/pages/gallery/gallery-animation.vue
+++ b/pages/gallery/gallery-animation.vue
@@ -1,5 +1,5 @@
 <template>
-	<canvas ref="canvasRef"></canvas>
+	<canvas ref="canvasRef" @click="$emit('click')"></canvas>
 </template>
 
 <script lang="ts">

--- a/pages/gallery/gallery-grid.vue
+++ b/pages/gallery/gallery-grid.vue
@@ -26,7 +26,8 @@
 							:src="texture.url"
 							:textureID="texture.textureID"
 							:ignoreList="ignoreList"
-							:animated="animated"
+							:isPlaying="isPlaying"
+							:animatedTextures="animatedTextures"
 						>
 							<h1 :style="missingTextStyles.texture_id">#{{ texture.textureID }}</h1>
 							<h3 :style="missingTextStyles.texture_name">{{ texture.name }}</h3>
@@ -94,8 +95,12 @@ export default {
 			type: Boolean,
 			required: true,
 		},
-		animated: {
+		isPlaying: {
 			type: Boolean,
+			required: true,
+		},
+		animatedTextures: {
+			type: Array,
 			required: true,
 		},
 		textures: {

--- a/pages/gallery/gallery-grid.vue
+++ b/pages/gallery/gallery-grid.vue
@@ -124,6 +124,10 @@ export default {
 			type: String,
 			required: true,
 		},
+		maxColumns: {
+			type: Number,
+			required: true,
+		},
 		error: {
 			type: String,
 			required: false,
@@ -189,17 +193,6 @@ export default {
 					return bContrib - aContrib;
 				},
 			};
-		},
-		maxColumns() {
-			const { xs, sm, md, lg, xl } = this.$vuetify.breakpoint;
-
-			// completely arbitrary values, feel free to change these
-			// based on https://v2.vuetifyjs.com/en/features/breakpoints/
-			if (xs) return 1;
-			if (sm) return 4;
-			if (md) return 8;
-			if (lg) return 12;
-			if (xl) return 16;
 		},
 		shownColumns() {
 			return Math.min(this.columns, this.maxColumns);

--- a/pages/gallery/gallery-grid.vue
+++ b/pages/gallery/gallery-grid.vue
@@ -99,10 +99,6 @@ export default {
 			type: Boolean,
 			required: true,
 		},
-		animatedTextures: {
-			type: Array,
-			required: true,
-		},
 		textures: {
 			type: Array,
 			required: true,
@@ -142,6 +138,8 @@ export default {
 			displayedResults: 1,
 			// go to the top arrow
 			scrollY: 0,
+			// list of animated textures ids
+			animatedTextures: [],
 		};
 	},
 	methods: {
@@ -244,6 +242,10 @@ export default {
 		},
 	},
 	created() {
+		axios.get(`${this.$root.apiURL}/textures/animated`).then((res) => {
+			this.animatedTextures = res.data.map((el) => el.toString());
+		});
+
 		axios.get(`${this.$root.apiURL}/contributions/raw`).then((res) => {
 			this.loadedContributions = Object.values(res.data)
 				.filter((contribution) => contribution.pack && contribution.texture)

--- a/pages/gallery/gallery-grid.vue
+++ b/pages/gallery/gallery-grid.vue
@@ -195,7 +195,7 @@ export default {
 
 			// completely arbitrary values, feel free to change these
 			// based on https://v2.vuetifyjs.com/en/features/breakpoints/
-			if (xs) return 2;
+			if (xs) return 1;
 			if (sm) return 4;
 			if (md) return 8;
 			if (lg) return 12;

--- a/pages/gallery/gallery-grid.vue
+++ b/pages/gallery/gallery-grid.vue
@@ -190,7 +190,7 @@ export default {
 
 			// completely arbitrary values, feel free to change these
 			// based on https://v2.vuetifyjs.com/en/features/breakpoints/
-			if (xs) return 1;
+			if (xs) return 2;
 			if (sm) return 4;
 			if (md) return 8;
 			if (lg) return 12;

--- a/pages/gallery/gallery-grid.vue
+++ b/pages/gallery/gallery-grid.vue
@@ -26,6 +26,7 @@
 							:src="texture.url"
 							:textureID="texture.textureID"
 							:ignoreList="ignoreList"
+							:animated="animated"
 						>
 							<h1 :style="missingTextStyles.texture_id">#{{ texture.textureID }}</h1>
 							<h3 :style="missingTextStyles.texture_name">{{ texture.name }}</h3>
@@ -90,6 +91,10 @@ export default {
 			required: true,
 		},
 		stretched: {
+			type: Boolean,
+			required: true,
+		},
+		animated: {
 			type: Boolean,
 			required: true,
 		},

--- a/pages/gallery/gallery-image.vue
+++ b/pages/gallery/gallery-image.vue
@@ -61,6 +61,11 @@ export default {
 			required: false,
 			default: true,
 		},
+		mcmeta: {
+			type: Object,
+			required: false,
+			default: null,
+		},
 		modal: {
 			type: Boolean,
 			required: false,
@@ -85,8 +90,10 @@ export default {
 	methods: {
 		textureNotFound() {
 			// fall back to default if ignored (simulates default behavior)
+			// + fetch animation if it exists
 			if (this.ignoreList.some((el) => this.src.includes(el))) {
 				this.imageURL = `${this.$root.apiURL}/textures/${this.textureID}/url/default/latest`;
+				this.fetchAnimation();
 				return;
 			}
 
@@ -94,6 +101,13 @@ export default {
 			this.exists = false;
 		},
 		fetchAnimation() {
+			// avoid fetching if already provided
+			if (this.mcmeta && this.mcmeta.animation) {
+				this.hasAnimation = true;
+				this.animation = this.mcmeta;
+				return;
+			}
+
 			void axios.get(`${this.$root.apiURL}/textures/${this.textureID}/mcmeta`)
 				.then((res) => {
 					if (res.data.animation) {

--- a/pages/gallery/gallery-image.vue
+++ b/pages/gallery/gallery-image.vue
@@ -5,7 +5,7 @@
 	>
 		<!-- send click events back to caller -->
 		<gallery-animation
-			v-if="animated && exists && hasAnimation"
+			v-if="isPlaying && exists && hasAnimation"
 			class="gallery-texture-image"
 			:src="imageURL"
 			:mcmeta="animation"
@@ -18,7 +18,7 @@
 			ref="imageRef"
 			:style="{ 
 				aspectRatio: 1, 
-				opacity: hasAnimation && animated ? 0 : 1 // allow the texture to be copied even if animation is present
+				opacity: hasAnimation && isPlaying ? 0 : 1 // allow the texture to be copied even if animation is present
 			}"
 			@error="textureNotFound"
 			@click="$emit('click')"
@@ -56,7 +56,7 @@ export default {
 			type: String,
 			required: true,
 		},
-		animated: {
+		isPlaying: {
 			type: Boolean,
 			required: false,
 			default: true,
@@ -77,6 +77,12 @@ export default {
 			required: false,
 			default: () => [],
 		},
+		// used to determine if the texture is animated thus fetching the mcmeta if not provided
+		animatedTextures: {
+			type: Array as () => string[],
+			required: false,
+			default: () => [],
+		},
 	},
 	data() {
 		return {
@@ -86,6 +92,11 @@ export default {
 			hasAnimation: false,
 			animation: {},
 		};
+	},
+	watch: {
+		animatedTextures() {
+			this.fetchAnimation();
+		},
 	},
 	methods: {
 		textureNotFound() {
@@ -105,6 +116,11 @@ export default {
 			if (this.mcmeta && this.mcmeta.animation) {
 				this.hasAnimation = true;
 				this.animation = this.mcmeta;
+				return;
+			}
+
+			if (this.animatedTextures.length > 0 && !this.animatedTextures.includes(this.textureID)) {
+				this.hasAnimation = false;
 				return;
 			}
 

--- a/pages/gallery/gallery-image.vue
+++ b/pages/gallery/gallery-image.vue
@@ -5,7 +5,7 @@
 	>
 		<!-- send click events back to caller -->
 		<gallery-animation
-			v-if="exists && hasAnimation"
+			v-if="animated && exists && hasAnimation"
 			class="gallery-texture-image"
 			:src="imageURL"
 			:mcmeta="animation"
@@ -18,7 +18,7 @@
 			ref="imageRef"
 			:style="{ 
 				aspectRatio: 1, 
-				opacity: hasAnimation ? 0 : 1 // allow the texture to be copied even if animation is present
+				opacity: hasAnimation && animated ? 0 : 1 // allow the texture to be copied even if animation is present
 			}"
 			@error="textureNotFound"
 			@click="$emit('click')"
@@ -55,6 +55,11 @@ export default {
 		textureID: {
 			type: String,
 			required: true,
+		},
+		animated: {
+			type: Boolean,
+			required: false,
+			default: true,
 		},
 		modal: {
 			type: Boolean,

--- a/pages/gallery/gallery-options.vue
+++ b/pages/gallery/gallery-options.vue
@@ -1,72 +1,54 @@
 <template>
 	<div class="py-2">
 		<v-row class="mb-2">
-			<v-col cols="12" sm="3">
+			<v-col cols="12" sm="6">
 				<v-select
-					outlined dense
+					dense
 					:items="packList"
 					item-text="label"
 					item-value="value"
 					:value="current.pack"
 					:label="$root.lang().gallery.category.pack"
 					@change="updateRoute($event, 'pack')"
-					hide-details
 				/>
 			</v-col>
 
-			<v-col cols="12" sm="3">
+			<v-col cols="12" sm="6">
 				<v-select
-					outlined dense
+					dense
 					:items="editionList"
 					item-text="label"
 					item-value="value"
 					:value="current.edition"
 					:label="$root.lang().gallery.category.edition"
 					@change="updateRoute($event, 'edition')"
-					hide-details
 				/>
 			</v-col>
-
-			<v-col cols="12" sm="3">
+		</v-row>
+		<v-row>
+			<v-col cols="12" sm="6">
 				<v-select
-					outlined dense
+					dense
 					:items="versionList"
 					:value="current.version"
 					item-text="label"
 					item-value="value"
 					:label="$root.lang().gallery.category.mc_version"
 					@change="updateRoute($event, 'version')"
-					hide-details
 				/>
 			</v-col>
 
-			<v-col cols="12" sm="3">
+			<v-col cols="12" sm="6">
 				<v-select
-					outlined dense
+					dense
 					:items="tagList"
 					item-text="label"
 					item-value="value"
 					:value="current.tag"
 					:label="$root.lang().gallery.category.tag"
 					@change="updateRoute($event, 'tag')"
-					hide-details
 				/>
 			</v-col>
-		</v-row>
-
-		<v-row class="mb-1 px-3">
-			<v-text-field
-				v-model="current.search"
-				:append-icon="current.search ? 'mdi-send' : undefined"
-				outlined dense
-				clear-icon="mdi-close"
-				clearable
-				hide-details
-				type="text"
-				:label="$root.lang().database.textures.search_texture"
-				@keyup.enter="startSearch"
-				@click:append="startSearch"
-			/>
 		</v-row>
 	</div>
 </template>
@@ -109,15 +91,6 @@ export default {
 
 			// actual updating is handled from main page
 			this.$emit("updateRoute");
-		},
-		startSearch() {
-			this.$emit("updateRoute");
-		},
-		clearSearch() {
-			// avoid restarting search if there's already nothing there
-			if (this.current.search === null) return;
-			this.current.search = null;
-			this.updateRoute();
 		},
 	},
 	computed: {

--- a/pages/gallery/gallery-options.vue
+++ b/pages/gallery/gallery-options.vue
@@ -1,51 +1,72 @@
 <template>
-	<div>
-		<v-row>
-			<v-col cols="12" sm="6">
+	<div class="py-2">
+		<v-row class="mb-2">
+			<v-col cols="12" sm="3">
 				<v-select
+					outlined dense
 					:items="packList"
 					item-text="label"
 					item-value="value"
 					:value="current.pack"
 					:label="$root.lang().gallery.category.pack"
 					@change="updateRoute($event, 'pack')"
+					hide-details
 				/>
 			</v-col>
 
-			<v-col cols="12" sm="6">
+			<v-col cols="12" sm="3">
 				<v-select
+					outlined dense
 					:items="editionList"
 					item-text="label"
 					item-value="value"
 					:value="current.edition"
 					:label="$root.lang().gallery.category.edition"
 					@change="updateRoute($event, 'edition')"
+					hide-details
 				/>
 			</v-col>
-		</v-row>
 
-		<v-row>
-			<v-col cols="12" sm="6">
+			<v-col cols="12" sm="3">
 				<v-select
+					outlined dense
 					:items="versionList"
 					:value="current.version"
 					item-text="label"
 					item-value="value"
 					:label="$root.lang().gallery.category.mc_version"
 					@change="updateRoute($event, 'version')"
+					hide-details
 				/>
 			</v-col>
 
-			<v-col cols="12" sm="6">
+			<v-col cols="12" sm="3">
 				<v-select
+					outlined dense
 					:items="tagList"
 					item-text="label"
 					item-value="value"
 					:value="current.tag"
 					:label="$root.lang().gallery.category.tag"
 					@change="updateRoute($event, 'tag')"
+					hide-details
 				/>
 			</v-col>
+		</v-row>
+
+		<v-row class="mb-1 px-3">
+			<v-text-field
+				v-model="current.search"
+				:append-icon="current.search ? 'mdi-send' : undefined"
+				outlined dense
+				clear-icon="mdi-close"
+				clearable
+				hide-details
+				type="text"
+				:label="$root.lang().database.textures.search_texture"
+				@keyup.enter="startSearch"
+				@click:append="startSearch"
+			/>
 		</v-row>
 	</div>
 </template>
@@ -89,6 +110,15 @@ export default {
 			// actual updating is handled from main page
 			this.$emit("updateRoute");
 		},
+		startSearch() {
+			this.$emit("updateRoute");
+		},
+		clearSearch() {
+			// avoid restarting search if there's already nothing there
+			if (this.current.search === null) return;
+			this.current.search = null;
+			this.updateRoute();
+		},
 	},
 	computed: {
 		packList() {
@@ -120,11 +150,14 @@ export default {
 			});
 		},
 		tagList() {
-			return this.options.tags.map((t) => ({
-				// tags are already title cased
-				label: t === "all" ? this.$root.lang().gallery.all : t,
-				value: t,
-			}));
+			return this.options.tags
+				// filter out java and bedrock tags as they're already covered by edition
+				.filter((t) => !['java', 'bedrock'].some(e => t.toLowerCase().includes(e)))
+				.map((t) => ({
+					// tags are already title cased
+					label: t === "all" ? this.$root.lang().gallery.all : t,
+					value: t,
+				}));
 		},
 	},
 	created() {

--- a/pages/gallery/gallery-options.vue
+++ b/pages/gallery/gallery-options.vue
@@ -1,9 +1,8 @@
 <template>
-	<div class="py-2">
-		<v-row class="mb-2">
+	<div>
+		<v-row>
 			<v-col cols="12" sm="6">
 				<v-select
-					dense
 					:items="packList"
 					item-text="label"
 					item-value="value"
@@ -15,7 +14,6 @@
 
 			<v-col cols="12" sm="6">
 				<v-select
-					dense
 					:items="editionList"
 					item-text="label"
 					item-value="value"
@@ -25,10 +23,10 @@
 				/>
 			</v-col>
 		</v-row>
+
 		<v-row>
 			<v-col cols="12" sm="6">
 				<v-select
-					dense
 					:items="versionList"
 					:value="current.version"
 					item-text="label"
@@ -40,7 +38,6 @@
 
 			<v-col cols="12" sm="6">
 				<v-select
-					dense
 					:items="tagList"
 					item-text="label"
 					item-value="value"
@@ -123,14 +120,16 @@ export default {
 			});
 		},
 		tagList() {
-			return this.options.tags
-				// filter out java and bedrock tags as they're already covered by edition
-				.filter((t) => !['java', 'bedrock'].some(e => t.toLowerCase().includes(e)))
-				.map((t) => ({
-					// tags are already title cased
-					label: t === "all" ? this.$root.lang().gallery.all : t,
-					value: t,
-				}));
+			return (
+				this.options.tags
+					// filter out java and bedrock tags as they're already covered by edition
+					.filter((t) => !["java", "bedrock"].includes(t.toLowerCase()))
+					.map((t) => ({
+						// tags are already title cased
+						label: t === "all" ? this.$root.lang().gallery.all : t,
+						value: t,
+					}))
+			);
 		},
 	},
 	created() {

--- a/pages/gallery/index.vue
+++ b/pages/gallery/index.vue
@@ -10,7 +10,7 @@
 		/>
 
 		<v-row class="pl-3 mt-0">
-			<v-col cols="12" :sm="stretched ? 3 : 4">
+			<v-col cols="12" :sm="stretched ? 3 : (isAbleToStretch ? 3 : 4)">
 				<v-slider
 					v-if="maxColumns > 2"
 					hide-details
@@ -25,13 +25,13 @@
 				/>
 			</v-col>
 
-			<v-col cols="12" :sm="2" p="0" class="py-0">
+			<v-col cols="12" :sm="2" p="0" v-if="isAbleToStretch">
 				<v-switch :label="$root.lang().gallery.stretched_switcher" v-model="stretched" />
 			</v-col>
-			<v-col cols="12" :sm="3" p="0" class="py-0">
+			<v-col cols="12" :sm="isAbleToStretch ? 3 : 4" p="0" :class="this.$vuetify.breakpoint.xs ? 'py-0' : ''">
 				<v-switch :label="$root.lang().gallery.animations_switcher" v-model="isPlaying" />
 			</v-col>
-			<v-col class="ml-auto" cols="12" sm="3" v-if="!$root.isAdmin">
+			<v-col class="ml-auto" cols="12" :sm="isAbleToStretch ? 3 : 4" v-if="!$root.isAdmin">
 				<v-btn block @click="clearCache">{{ $root.lang().gallery.clear_cache }}</v-btn>
 			</v-col>
 		</v-row>
@@ -291,6 +291,10 @@ export default {
 			if (md) return 8;
 			if (lg) return 12;
 			if (xl) return 16;
+		},
+		// hide the stretched switcher when the screen is smaller than the size when not stretched
+		isAbleToStretch() {
+			return this.$vuetify.breakpoint.width > 1056;
 		},
 	},
 	watch: {

--- a/pages/gallery/index.vue
+++ b/pages/gallery/index.vue
@@ -1,13 +1,17 @@
 <template>
 	<v-container :style="stretched ? 'max-width: 100% !important' : ''">
 		<div class="text-h4 py-4">{{ $root.lang().gallery.title }}</div>
+		<div class="my-2 text-h5">{{ $root.lang().gallery.category.search }}</div>
 
-		<gallery-options v-model="current" :packToName="packToName" @updateRoute="updateRoute" />
+		<gallery-options 
+			v-model="current"
+			:packToName="packToName" 
+			@updateRoute="updateRoute" 
+		/>
 
-		<v-row class="my-2">
-			<v-col cols="12" sm="6">
+		<v-row class="pl-3 mt-0">
+			<v-col cols="12" :sm="stretched ? 3 : 4">
 				<v-slider
-					:label="$root.lang().gallery.max_items_per_row"
 					v-model="columns"
 					step="1"
 					thumb-label
@@ -16,34 +20,24 @@
 					hide-details
 					min="1"
 					max="16"
+					prepend-icon="mdi-grid"
 				/>
 			</v-col>
-			<v-col cols="12" :sm="$root.isAdmin ? 3 : 6">
+
+			<v-col cols="12" :sm="2" p="0" class="py-0">
 				<v-switch :label="$root.lang().gallery.stretched_switcher" v-model="stretched" />
 			</v-col>
-			<v-col cols="12" sm="3" v-if="$root.isAdmin">
+			<v-col cols="12" :sm="3" p="0" class="py-0">
+				<v-switch :label="$root.lang().gallery.animations_switcher" v-model="animated" />
+			</v-col>
+			<v-col class="ml-auto" cols="12" sm="3" v-if="!$root.isAdmin">
 				<v-btn block @click="clearCache">{{ $root.lang().gallery.clear_cache }}</v-btn>
 			</v-col>
 		</v-row>
 
-		<div class="my-2 text-h5">{{ $root.lang().gallery.category.search }}</div>
-		<v-text-field
-			v-model="current.search"
-			:append-icon="current.search ? 'mdi-send' : undefined"
-			filled
-			clear-icon="mdi-close"
-			clearable
-			hide-details
-			:placeholder="$root.lang().database.textures.search_texture"
-			type="text"
-			@keyup.enter="startSearch"
-			@click:append="startSearch"
-			@click:clear="clearSearch"
-		/>
-
-		<v-row class="py-3 pb-0">
-			<v-col cols="12" sm="9" v-if="requestTime > 0 && textures.length">
-				<p class="text--secondary">
+		<v-row class="pb-0">
+			<v-col cols="12" sm="9"v-if="requestTime > 0 && textures.length">
+				<p class="text--secondary pl-2 mb-0">
 					{{ resultMessage }}
 				</p>
 			</v-col>
@@ -67,6 +61,7 @@
 			v-model="columns"
 			:loading="loading"
 			:stretched="stretched"
+			:animated="animated"
 			:textures="textures"
 			:pack="current.pack"
 			:ignoreList="ignoreList"
@@ -100,6 +95,7 @@ import GalleryModal from "./modal/index.vue";
 
 const COLUMN_KEY = "gallery_columns";
 const STRETCHED_KEY = "gallery_stretched";
+const ANIMATED_KEY = "gallery_animated";
 const SORT_KEY = "gallery_sort";
 
 export default {
@@ -114,6 +110,8 @@ export default {
 		return {
 			// whether the page shouldn't be stretched to the full width
 			stretched: localStorage.getItem(STRETCHED_KEY) === "true",
+			// whether to show animated textures
+			animated: localStorage.getItem(ANIMATED_KEY) === "true",
 			// number of columns you want to display
 			columns: Number(localStorage.getItem(COLUMN_KEY) || 7),
 			// whether search is loading
@@ -191,15 +189,6 @@ export default {
 		},
 		discordIDtoName(d) {
 			return this.authors[d]?.username || this.$root.lang().gallery.error_message.user_anonymous;
-		},
-		startSearch() {
-			this.updateRoute();
-		},
-		clearSearch() {
-			// avoid restarting search if there's already nothing there
-			if (this.current.search === null) return;
-			this.current.search = null;
-			this.updateRoute();
 		},
 		updateRoute() {
 			let route = `/gallery/${this.current.edition}/${this.current.pack}/${this.current.version}/${this.current.tag}`;
@@ -326,6 +315,9 @@ export default {
 		},
 		stretched(n) {
 			localStorage.setItem(STRETCHED_KEY, n);
+		},
+		animated(n) {
+			localStorage.setItem(ANIMATED_KEY, n);
 		},
 		currentSort(n) {
 			localStorage.setItem(SORT_KEY, n);

--- a/pages/gallery/index.vue
+++ b/pages/gallery/index.vue
@@ -1,35 +1,32 @@
 <template>
 	<v-container :style="stretched ? 'max-width: 100% !important' : ''">
 		<div class="text-h4 py-4">{{ $root.lang().gallery.title }}</div>
-		<div class="my-2 text-h5">{{ $root.lang().gallery.category.search }}</div>
 
-		<gallery-options 
-			v-model="current"
-			:packToName="packToName" 
-			@updateRoute="updateRoute" 
-		/>
+		<gallery-options v-model="current" :packToName="packToName" @updateRoute="updateRoute" />
 
-		<v-row class="pl-3 mt-0">
-			<v-col cols="12" :sm="stretched ? 3 : (isAbleToStretch ? 3 : 4)">
+		<v-row class="my-2">
+			<v-col cols="12" :sm="stretched ? 3 : isAbleToStretch ? 3 : 4">
 				<v-slider
-					v-if="maxColumns > 2"
-					hide-details
 					v-model="columns"
 					step="1"
 					thumb-label
 					ticks="always"
 					tick-size="4"
+					hide-details
 					min="2"
 					:max="maxColumns"
-					prepend-icon="mdi-grid"
 				/>
 			</v-col>
 
 			<v-col cols="12" :sm="2" p="0" v-if="isAbleToStretch">
 				<v-switch :label="$root.lang().gallery.stretched_switcher" v-model="stretched" />
 			</v-col>
-			<v-col cols="12" :sm="isAbleToStretch ? 3 : 4" p="0" :class="this.$vuetify.breakpoint.xs ? 'py-0' : ''">
-				<v-switch :label="$root.lang().gallery.animations_switcher" v-model="isPlaying" />
+			<v-col
+				cols="12"
+				:sm="isAbleToStretch ? 3 : 4"
+				:class="this.$vuetify.breakpoint.xs ? 'py-0' : ''"
+			>
+				<v-switch :label="$root.lang().gallery.animated_switcher" v-model="isPlaying" />
 			</v-col>
 			<v-col class="ml-auto" cols="12" :sm="isAbleToStretch ? 3 : 4" v-if="!$root.isAdmin">
 				<v-btn block @click="clearCache">{{ $root.lang().gallery.clear_cache }}</v-btn>
@@ -51,11 +48,9 @@
 			@click:clear="clearSearch"
 		/>
 
-		<v-row class="pb-0">
-			<v-col cols="12" sm="9"v-if="requestTime > 0 && textures.length">
-				<p class="text--secondary pl-2 mb-0">
-					{{ resultMessage }}
-				</p>
+		<v-row class="py-3 pb-0">
+			<v-col cols="12" sm="9" v-if="requestTime > 0 && textures.length">
+				<p class="text--secondary">{{ resultMessage }}</p>
 			</v-col>
 			<v-col cols="12" sm="9" v-else>
 				<br />
@@ -367,31 +362,31 @@ export default {
 		},
 	},
 	created() {
-		axios.get(`${this.$root.apiURL}/textures/animated`)
-			.then((res) => {
-				this.animatedTextures = res.data.map((el) => el.toString());
-			});
+		axios.get(`${this.$root.apiURL}/textures/animated`).then((res) => {
+			this.animatedTextures = res.data.map((el) => el.toString());
+		});
 
-		axios.get("https://raw.githubusercontent.com/Faithful-Resource-Pack/CompliBot/main/json/ignored_textures.json")
+		axios
+			.get(
+				"https://raw.githubusercontent.com/Faithful-Resource-Pack/CompliBot/main/json/ignored_textures.json",
+			)
 			.then((res) => {
 				this.ignoredTextures = res.data;
 			});
 
-		axios.get(`${this.$root.apiURL}/packs/raw`)
-			.then((res) => {
-				this.packToName = Object.values(res.data).reduce((acc, cur) => {
-					acc[cur.id] = cur.name;
-					return acc;
-				}, {});
-			});
+		axios.get(`${this.$root.apiURL}/packs/raw`).then((res) => {
+			this.packToName = Object.values(res.data).reduce((acc, cur) => {
+				acc[cur.id] = cur.name;
+				return acc;
+			}, {});
+		});
 
-		axios.get(`${this.$root.apiURL}/contributions/authors`)
-			.then((res) => {
-				this.authors = res.data.reduce((acc, cur) => {
-					acc[cur.id] = cur;
-					return acc;
-				}, {});
-			});
+		axios.get(`${this.$root.apiURL}/contributions/authors`).then((res) => {
+			this.authors = res.data.reduce((acc, cur) => {
+				acc[cur.id] = cur;
+				return acc;
+			}, {});
+		});
 	},
 };
 </script>

--- a/pages/gallery/index.vue
+++ b/pages/gallery/index.vue
@@ -74,7 +74,6 @@
 			:textures="textures"
 			:pack="current.pack"
 			:ignoreList="ignoreList"
-			:animatedTextures="animatedTextures"
 			:discordIDtoName="discordIDtoName"
 			:sort="currentSort"
 			:maxColumns="maxColumns"
@@ -166,8 +165,6 @@ export default {
 			},
 			// json of ignored textures (used in gallery images for fallbacks)
 			ignoredTextures: {},
-			// list of animated textures ids
-			animatedTextures: [],
 			abortController: new AbortController(),
 		};
 	},
@@ -365,10 +362,6 @@ export default {
 		},
 	},
 	created() {
-		axios.get(`${this.$root.apiURL}/textures/animated`).then((res) => {
-			this.animatedTextures = res.data.map((el) => el.toString());
-		});
-
 		axios
 			.get(
 				"https://raw.githubusercontent.com/Faithful-Resource-Pack/CompliBot/main/json/ignored_textures.json",

--- a/pages/gallery/index.vue
+++ b/pages/gallery/index.vue
@@ -12,14 +12,15 @@
 		<v-row class="pl-3 mt-0">
 			<v-col cols="12" :sm="stretched ? 3 : 4">
 				<v-slider
+					v-if="maxColumns > 2"
+					hide-details
 					v-model="columns"
 					step="1"
 					thumb-label
 					ticks="always"
 					tick-size="4"
-					hide-details
-					min="1"
-					max="16"
+					min="2"
+					:max="maxColumns"
 					prepend-icon="mdi-grid"
 				/>
 			</v-col>
@@ -276,6 +277,17 @@ export default {
 		},
 		modalTextureID() {
 			return this.$route.query.show;
+		},
+		maxColumns() {
+			const { xs, sm, md, lg, xl } = this.$vuetify.breakpoint;
+
+			// completely arbitrary values, feel free to change these
+			// based on https://v2.vuetifyjs.com/en/features/breakpoints/
+			if (xs) return 2;
+			if (sm) return 4;
+			if (md) return 8;
+			if (lg) return 12;
+			if (xl) return 16;
 		},
 	},
 	watch: {

--- a/pages/gallery/index.vue
+++ b/pages/gallery/index.vue
@@ -36,6 +36,21 @@
 			</v-col>
 		</v-row>
 
+		<div class="my-2 text-h5">{{ $root.lang().gallery.category.search }}</div>
+		<v-text-field
+			v-model="current.search"
+			:append-icon="current.search ? 'mdi-send' : undefined"
+			filled
+			clear-icon="mdi-close"
+			clearable
+			hide-details
+			:placeholder="$root.lang().database.textures.search_texture"
+			type="text"
+			@keyup.enter="startSearch"
+			@click:append="startSearch"
+			@click:clear="clearSearch"
+		/>
+
 		<v-row class="pb-0">
 			<v-col cols="12" sm="9"v-if="requestTime > 0 && textures.length">
 				<p class="text--secondary pl-2 mb-0">
@@ -193,6 +208,15 @@ export default {
 		},
 		discordIDtoName(d) {
 			return this.authors[d]?.username || this.$root.lang().gallery.error_message.user_anonymous;
+		},
+		startSearch() {
+			this.updateRoute();
+		},
+		clearSearch() {
+			// avoid restarting search if there's already nothing there
+			if (this.current.search === null) return;
+			this.current.search = null;
+			this.updateRoute();
 		},
 		updateRoute() {
 			let route = `/gallery/${this.current.edition}/${this.current.pack}/${this.current.version}/${this.current.tag}`;

--- a/pages/gallery/index.vue
+++ b/pages/gallery/index.vue
@@ -29,7 +29,7 @@
 				<v-switch :label="$root.lang().gallery.stretched_switcher" v-model="stretched" />
 			</v-col>
 			<v-col cols="12" :sm="3" p="0" class="py-0">
-				<v-switch :label="$root.lang().gallery.animations_switcher" v-model="animated" />
+				<v-switch :label="$root.lang().gallery.animations_switcher" v-model="isPlaying" />
 			</v-col>
 			<v-col class="ml-auto" cols="12" sm="3" v-if="!$root.isAdmin">
 				<v-btn block @click="clearCache">{{ $root.lang().gallery.clear_cache }}</v-btn>
@@ -62,10 +62,11 @@
 			v-model="columns"
 			:loading="loading"
 			:stretched="stretched"
-			:animated="animated"
+			:isPlaying="isPlaying"
 			:textures="textures"
 			:pack="current.pack"
 			:ignoreList="ignoreList"
+			:animatedTextures="animatedTextures"
 			:discordIDtoName="discordIDtoName"
 			:sort="currentSort"
 			:error="error"
@@ -112,7 +113,9 @@ export default {
 			// whether the page shouldn't be stretched to the full width
 			stretched: localStorage.getItem(STRETCHED_KEY) === "true",
 			// whether to show animated textures
-			animated: localStorage.getItem(ANIMATED_KEY) === "true",
+			isPlaying: localStorage.getItem(ANIMATED_KEY) === "true",
+			// list of animated textures ids
+			animatedTextures: [],
 			// number of columns you want to display
 			columns: Number(localStorage.getItem(COLUMN_KEY) || 7),
 			// whether search is loading
@@ -328,7 +331,7 @@ export default {
 		stretched(n) {
 			localStorage.setItem(STRETCHED_KEY, n);
 		},
-		animated(n) {
+		isPlaying(n) {
 			localStorage.setItem(ANIMATED_KEY, n);
 		},
 		currentSort(n) {
@@ -336,26 +339,31 @@ export default {
 		},
 	},
 	created() {
-		axios
-			.get(
-				"https://raw.githubusercontent.com/Faithful-Resource-Pack/CompliBot/main/json/ignored_textures.json",
-			)
+		axios.get(`${this.$root.apiURL}/textures/animated`)
+			.then((res) => {
+				this.animatedTextures = res.data.map((el) => el.toString());
+			});
+
+		axios.get("https://raw.githubusercontent.com/Faithful-Resource-Pack/CompliBot/main/json/ignored_textures.json")
 			.then((res) => {
 				this.ignoredTextures = res.data;
 			});
 
-		axios.get(`${this.$root.apiURL}/packs/raw`).then((res) => {
-			this.packToName = Object.values(res.data).reduce((acc, cur) => {
-				acc[cur.id] = cur.name;
-				return acc;
-			}, {});
-		});
-		axios.get(`${this.$root.apiURL}/contributions/authors`).then((res) => {
-			this.authors = res.data.reduce((acc, cur) => {
-				acc[cur.id] = cur;
-				return acc;
-			}, {});
-		});
+		axios.get(`${this.$root.apiURL}/packs/raw`)
+			.then((res) => {
+				this.packToName = Object.values(res.data).reduce((acc, cur) => {
+					acc[cur.id] = cur.name;
+					return acc;
+				}, {});
+			});
+
+		axios.get(`${this.$root.apiURL}/contributions/authors`)
+			.then((res) => {
+				this.authors = res.data.reduce((acc, cur) => {
+					acc[cur.id] = cur;
+					return acc;
+				}, {});
+			});
 	},
 };
 </script>

--- a/pages/gallery/modal/animation-tab.vue
+++ b/pages/gallery/modal/animation-tab.vue
@@ -27,10 +27,10 @@ export default {
 			required: true,
 		},
 	},
-	data() {
-		return {
-			jsonData: JSON.stringify(this.mcmeta, null, 2),
-		};
+	computed: {
+		jsonData() {
+			return JSON.stringify(this.mcmeta, null, 2);
+		},
 	},
 	methods: {
 		highlighter(code) {

--- a/pages/gallery/modal/animation-tab.vue
+++ b/pages/gallery/modal/animation-tab.vue
@@ -1,0 +1,41 @@
+<template>
+	<div class="gallery-info">
+		<h2>{{ $root.lang().gallery.modal.animation.texture_mcmeta }}</h2>
+		<prism-editor
+			class="my-editor"
+			v-model="jsonData"
+			:highlight="highlighter"
+			line-numbers
+			readonly
+		/>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import Prism from "prismjs";
+import { PrismEditor } from "vue-prism-editor";
+
+export default defineComponent({
+	name: 'AnimationTab',
+	components: {
+		PrismEditor,
+	},
+	props: {
+		mcmeta: {
+			type: Object,
+			required: true,
+		},
+	},
+	data() {
+		return {
+			jsonData: JSON.stringify(this.mcmeta, null, 2),
+		};
+	},
+	methods: {
+		highlighter(code) {
+			return Prism.highlight(code, Prism.languages.js, "json");
+		},
+	},
+});
+</script>

--- a/pages/gallery/modal/animation-tab.vue
+++ b/pages/gallery/modal/animation-tab.vue
@@ -1,7 +1,8 @@
 <template>
-	<div class="gallery-info">
+	<div class="gallery-info py-3">
 		<h2>{{ $root.lang().gallery.modal.animation.texture_mcmeta }}</h2>
 		<prism-editor
+			style="margin-top: 10px"
 			class="my-editor"
 			v-model="jsonData"
 			:highlight="highlighter"

--- a/pages/gallery/modal/animation-tab.vue
+++ b/pages/gallery/modal/animation-tab.vue
@@ -11,13 +11,12 @@
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script>
 import Prism from "prismjs";
 import { PrismEditor } from "vue-prism-editor";
 
-export default defineComponent({
-	name: 'AnimationTab',
+export default {
+	name: "animation-tab",
 	components: {
 		PrismEditor,
 	},
@@ -37,5 +36,5 @@ export default defineComponent({
 			return Prism.highlight(code, Prism.languages.js, "json");
 		},
 	},
-});
+};
 </script>

--- a/pages/gallery/modal/index.vue
+++ b/pages/gallery/modal/index.vue
@@ -45,13 +45,13 @@
 				<v-tabs-items v-model="selectedTab">
 					<v-tab-item v-for="tab in displayedTabs" :key="tab">
 						<texture-tab v-if="tab === displayedTabs.information" :textureObj="textureObj" />
-						<animation-tab v-if="tab === displayedTabs.animation" :mcmeta="textureObj.mcmeta" />
 						<author-tab
 							v-if="tab === displayedTabs.authors"
 							:contributions="textureObj.contributions"
 							:packToName="packToName"
 							:discordIDtoName="discordIDtoName"
 						/>
+						<animation-tab v-if="tab === displayedTabs.animation" :mcmeta="textureObj.mcmeta" />
 					</v-tab-item>
 				</v-tabs-items>
 			</div>
@@ -164,16 +164,15 @@ export default {
 			return `[#${this.textureID}] ${this.textureObj.texture.name}`;
 		},
 		displayedTabs() {
-			const tabs = {
-				information: this.$root.lang().gallery.modal.tabs.information,
-				animation: this.$root.lang().gallery.modal.tabs.animation,
-				authors: this.$root.lang().gallery.modal.tabs.authors,
-			};
+			const availableTabs = ["information", "authors"];
 
-			// remove animation tab if there's no mcmeta data
-			if (!Object.keys(this.textureObj.mcmeta).length) delete tabs.animation;
+			// only show animation tab if there's an mcmeta
+			if (Object.keys(this.textureObj.mcmeta).length) availableTabs.push("animation");
 
-			return tabs;
+			return availableTabs.reduce((acc, cur) => {
+				acc[cur] = this.$root.lang().gallery.modal.tabs[cur];
+				return acc;
+			}, {});
 		},
 	},
 	watch: {

--- a/pages/gallery/modal/index.vue
+++ b/pages/gallery/modal/index.vue
@@ -164,7 +164,11 @@ export default {
 			return `[#${this.textureID}] ${this.textureObj.texture.name}`;
 		},
 		displayedTabs() {
-			const tabs = this.$root.lang().gallery.modal.tabs;
+			const tabs = {
+				information: this.$root.lang().gallery.modal.tabs.information,
+				animation: this.$root.lang().gallery.modal.tabs.animation,
+				authors: this.$root.lang().gallery.modal.tabs.authors,
+			};
 
 			// remove animation tab if there's no mcmeta data
 			if (!Object.keys(this.textureObj.mcmeta).length) delete tabs.animation;

--- a/pages/gallery/modal/index.vue
+++ b/pages/gallery/modal/index.vue
@@ -22,6 +22,7 @@
 							:src="url.image"
 							:textureID="textureID"
 							:ignoreList="ignoreList"
+							:mcmeta="textureObj.mcmeta"
 							@click="openFullscreenPreview(url.image)"
 						>
 							<p>{{ $root.lang().gallery.error_message.texture_not_done }}</p>

--- a/pages/gallery/modal/index.vue
+++ b/pages/gallery/modal/index.vue
@@ -36,16 +36,24 @@
 			<div class="flex-grow-1 pa-2">
 				<v-tabs id="info-tabs" v-model="selectedTab" :show-arrows="false">
 					<v-tabs-slider />
-					<v-tab v-for="tab in tabs" :key="tab" style="text-transform: uppercase">
+
+					<v-tab v-for="tab in displayedTabs" :key="tab" style="text-transform: uppercase">
 						{{ tab }}
 					</v-tab>
 				</v-tabs>
 
 				<v-tabs-items v-model="selectedTab">
-					<v-tab-item v-for="tab in tabs" :key="tab">
-						<texture-tab v-if="tab === tabs.information" :textureObj="textureObj" />
+					<v-tab-item v-for="tab in displayedTabs" :key="tab">
+						<texture-tab 
+							v-if="tab === displayedTabs.information" 
+							:textureObj="textureObj" 
+						/>
+						<animation-tab
+							v-if="tab === displayedTabs.animation"
+							:mcmeta="textureObj.mcmeta"
+						/>
 						<author-tab
-							v-if="tab === tabs.authors"
+							v-if="tab === displayedTabs.authors"
 							:contributions="textureObj.contributions"
 							:packToName="packToName"
 							:discordIDtoName="discordIDtoName"
@@ -62,6 +70,7 @@ import axios from "axios";
 import GalleryImage from "../gallery-image.vue";
 import TextureTab from "./texture-tab.vue";
 import AuthorTab from "./author-tab.vue";
+import AnimationTab from "./animation-tab.vue";
 import FullscreenPreview from "@components/fullscreen-preview.vue";
 import FullscreenModal from "@components/fullscreen-modal.vue";
 
@@ -89,6 +98,7 @@ export default {
 		FullscreenPreview,
 		FullscreenModal,
 		TextureTab,
+		AnimationTab,
 		AuthorTab,
 	},
 	props: {
@@ -119,7 +129,6 @@ export default {
 		return {
 			textureObj: {},
 			selectedTab: null,
-			tabs: this.$root.lang().gallery.modal.tabs,
 			modalOpened: false,
 			clickedImage: "",
 			previewOpen: false,
@@ -160,6 +169,20 @@ export default {
 			if (this.loading) return this.$root.lang().global.loading;
 			return `[#${this.textureID}] ${this.textureObj.texture.name}`;
 		},
+		displayedTabs() {
+			const tabs = {
+				information: this.$root.lang().gallery.modal.tabs.information,
+				animation: this.$root.lang().gallery.modal.tabs.animation,
+				authors: this.$root.lang().gallery.modal.tabs.authors,
+			}
+
+			// remove animation tab if no mcmeta data
+			if (Object.keys(this.textureObj.mcmeta).length === 0) {
+				delete tabs.animation;
+			}
+			
+			return tabs;
+		}
 	},
 	watch: {
 		textureID: {

--- a/pages/gallery/modal/index.vue
+++ b/pages/gallery/modal/index.vue
@@ -44,14 +44,8 @@
 
 				<v-tabs-items v-model="selectedTab">
 					<v-tab-item v-for="tab in displayedTabs" :key="tab">
-						<texture-tab 
-							v-if="tab === displayedTabs.information" 
-							:textureObj="textureObj" 
-						/>
-						<animation-tab
-							v-if="tab === displayedTabs.animation"
-							:mcmeta="textureObj.mcmeta"
-						/>
+						<texture-tab v-if="tab === displayedTabs.information" :textureObj="textureObj" />
+						<animation-tab v-if="tab === displayedTabs.animation" :mcmeta="textureObj.mcmeta" />
 						<author-tab
 							v-if="tab === displayedTabs.authors"
 							:contributions="textureObj.contributions"
@@ -170,19 +164,13 @@ export default {
 			return `[#${this.textureID}] ${this.textureObj.texture.name}`;
 		},
 		displayedTabs() {
-			const tabs = {
-				information: this.$root.lang().gallery.modal.tabs.information,
-				animation: this.$root.lang().gallery.modal.tabs.animation,
-				authors: this.$root.lang().gallery.modal.tabs.authors,
-			}
+			const tabs = this.$root.lang().gallery.modal.tabs;
 
-			// remove animation tab if no mcmeta data
-			if (Object.keys(this.textureObj.mcmeta).length === 0) {
-				delete tabs.animation;
-			}
-			
+			// remove animation tab if there's no mcmeta data
+			if (!Object.keys(this.textureObj.mcmeta).length) delete tabs.animation;
+
 			return tabs;
-		}
+		},
 	},
 	watch: {
 		textureID: {

--- a/resources/css/webapp.css
+++ b/resources/css/webapp.css
@@ -657,6 +657,10 @@ code {
 	cursor: pointer;
 }
 
+.gallery-animated-image {
+	aspect-ratio: 1;
+}
+
 .gallery-texture-background > .v-image__image {
 	image-rendering: pixelated;
 	background-repeat: repeat;

--- a/resources/strings/en_US.js
+++ b/resources/strings/en_US.js
@@ -549,7 +549,7 @@ export default {
 	gallery: {
 		stretched_switcher: "Full width view",
 		share_link_copied_to_clipboard: "Share link copied to clipboard",
-		animations_switcher: "Play animated textures",
+		animated_switcher: "Play animated textures",
 		title: "Gallery",
 		loading_message: "Loading…",
 		error_message: {

--- a/resources/strings/en_US.js
+++ b/resources/strings/en_US.js
@@ -547,9 +547,10 @@ export default {
 		},
 	},
 	gallery: {
+		max_items_per_row: "Max items per row",
 		stretched_switcher: "Full width view",
-		share_link_copied_to_clipboard: "Share link copied to clipboard",
 		animated_switcher: "Play animated textures",
+		share_link_copied_to_clipboard: "Share link copied to clipboard",
 		title: "Gallery",
 		loading_message: "Loading…",
 		error_message: {
@@ -587,8 +588,8 @@ export default {
 			no_contributions: "No contributions found",
 			tabs: {
 				information: "information",
-				animation: "animation",
 				authors: "authors",
+				animation: "animation",
 			},
 			info: {
 				texture: "Texture",

--- a/resources/strings/en_US.js
+++ b/resources/strings/en_US.js
@@ -549,7 +549,7 @@ export default {
 	gallery: {
 		stretched_switcher: "Full width view",
 		share_link_copied_to_clipboard: "Share link copied to clipboard",
-		max_items_per_row: "Max items per row",
+		animations_switcher: "Play animated textures",
 		title: "Gallery",
 		loading_message: "Loading…",
 		error_message: {

--- a/resources/strings/en_US.js
+++ b/resources/strings/en_US.js
@@ -587,12 +587,16 @@ export default {
 			no_contributions: "No contributions found",
 			tabs: {
 				information: "information",
+				animation: "animation",
 				authors: "authors",
 			},
 			info: {
 				texture: "Texture",
 				uses: "Uses",
 				paths: "Paths",
+			},
+			animation: {
+				texture_mcmeta: "MCMETA",
 			},
 			data: {
 				contribution_id: "Contribution ID",

--- a/resources/strings/es_ES.js
+++ b/resources/strings/es_ES.js
@@ -539,7 +539,7 @@ export default {
 	gallery: {
 		stretched_switcher: "Vista de ancho completo",
 		share_link_copied_to_clipboard: "Enlace para compartir copiado al portapapeles",
-		animations_switcher: "Mostrar animaciones",
+		animated_switcher: "Mostrar animaciones",
 		title: "Galería",
 		loading_message: "Cargando…",
 		error_message: {

--- a/resources/strings/es_ES.js
+++ b/resources/strings/es_ES.js
@@ -539,7 +539,7 @@ export default {
 	gallery: {
 		stretched_switcher: "Vista de ancho completo",
 		share_link_copied_to_clipboard: "Enlace para compartir copiado al portapapeles",
-		max_items_per_row: "Máximo de artículos por fila",
+		animations_switcher: "Mostrar animaciones",
 		title: "Galería",
 		loading_message: "Cargando…",
 		error_message: {

--- a/resources/strings/es_ES.js
+++ b/resources/strings/es_ES.js
@@ -537,9 +537,10 @@ export default {
 		},
 	},
 	gallery: {
+		max_items_per_row: "Máximo de artículos por fila",
 		stretched_switcher: "Vista de ancho completo",
-		share_link_copied_to_clipboard: "Enlace para compartir copiado al portapapeles",
 		animated_switcher: "Mostrar animaciones",
+		share_link_copied_to_clipboard: "Enlace para compartir copiado al portapapeles",
 		title: "Galería",
 		loading_message: "Cargando…",
 		error_message: {

--- a/resources/strings/fr_FR.js
+++ b/resources/strings/fr_FR.js
@@ -421,7 +421,7 @@ export default {
 		},
 	},
 	gallery: {
-		max_items_per_row: "Maximum d'items par ligne",
+		animations_switcher: "Jouer les animations",
 		all: "Tout",
 		title: "Galerie",
 		loading_message: "Chargement…",

--- a/resources/strings/fr_FR.js
+++ b/resources/strings/fr_FR.js
@@ -421,6 +421,7 @@ export default {
 		},
 	},
 	gallery: {
+		max_items_per_row: "Maximum d'items par ligne",
 		animated_switcher: "Jouer les animations",
 		all: "Tout",
 		title: "Galerie",

--- a/resources/strings/fr_FR.js
+++ b/resources/strings/fr_FR.js
@@ -421,7 +421,7 @@ export default {
 		},
 	},
 	gallery: {
-		animations_switcher: "Jouer les animations",
+		animated_switcher: "Jouer les animations",
 		all: "Tout",
 		title: "Galerie",
 		loading_message: "Chargement…",


### PR DESCRIPTION
### Preview:

![image](https://github.com/user-attachments/assets/454f1212-e960-49af-a9e4-830cde870e42)
![image](https://github.com/user-attachments/assets/885088dc-3fd8-4fe1-afb4-dbcd8eec86ee)

### API

Please merge this one first: https://github.com/Faithful-Resource-Pack/API/pull/70

### To-do:

- `gallery-image`:
  - [x] Allow right-click copy image on canvas
  - [x] Optimisation: Find memory leaks

- Texture modal:
  - [x] Display the MCMETA in a specific tab
  
- Gallery:
  - [x] Add a play animation switch in the gallery options
    - The screenshot above is me filtering the texture to only have the animated one, this switch only turns the animation off, displaying the textures like they are actually displayed in prod

- Other stuff:
  - [x] ~~Hard-coded mcmeta for the flowing/still milk textures?~~
    - It appears that there is a weird behavior with modded textures that are both ignored but contributed to

