### PR TITLE
Fix gallery slider

### DIFF
--- a/pages/gallery/gallery-grid.vue
+++ b/pages/gallery/gallery-grid.vue
@@ -118,7 +118,7 @@ export default {
 		return {
 			loadedContributions: {},
 			lastContributions: {},
-			columns: 7,
+			columns: this.value,
 			// number of displayed results
 			displayedResults: 1,
 			// styles


### PR DESCRIPTION
The grid was always taking 7 as default value rather than taking the given value from localstorage which was making the localstorage pointless aha