### PR TITLE
Texture merging frontend

### DIFF
--- a/pages/texture/index.vue
+++ b/pages/texture/index.vue
@@ -37,6 +37,16 @@
 				}
 			"
 		/>
+		<merge-texture-modal
+			v-model="mergeModalOpen"
+			:color="pageColor"
+			@close="
+				() => {
+					mergeModalOpen = false;
+					getTextures();
+				}
+			"
+		/>
 		<texture-remove-confirm
 			v-model="remove.confirm"
 			type="texture"
@@ -85,8 +95,9 @@
 		<div class="my-6">
 			<v-row>
 				<v-col>
-					<v-btn block :color="pageColor" :class="[textColorOnPage]" @click="openNewTextureModal()">
-						{{ $root.lang().database.textures.add_multiple }}<v-icon right>mdi-plus</v-icon>
+					<v-btn block :color="pageColor" :class="[textColorOnPage]" @click="openNewTextureModal">
+						{{ $root.lang().database.textures.add_multiple }}
+						<v-icon right>mdi-plus</v-icon>
 					</v-btn>
 				</v-col>
 			</v-row>
@@ -94,7 +105,8 @@
 			<v-row>
 				<v-col>
 					<v-btn block :color="pageColor" :class="[textColorOnPage]" @click="openAddVersionModal">
-						{{ $root.lang().database.textures.add_version.title }}<v-icon right>mdi-plus</v-icon>
+						{{ $root.lang().database.textures.add_version.title }}
+						<v-icon right>mdi-pencil-plus</v-icon>
 					</v-btn>
 				</v-col>
 				<v-col>
@@ -104,7 +116,14 @@
 						:class="[textColorOnPage]"
 						@click="openRenameVersionModal"
 					>
-						{{ $root.lang().database.textures.rename_version.title }}<v-icon right>mdi-plus</v-icon>
+						{{ $root.lang().database.textures.rename_version.title }}
+						<v-icon right>mdi-pencil</v-icon>
+					</v-btn>
+				</v-col>
+				<v-col>
+					<v-btn block :color="pageColor" :class="[textColorOnPage]" @click="openMergeModal">
+						{{ $root.lang().database.textures.merge_textures.title }}
+						<v-icon right>mdi-merge</v-icon>
 					</v-btn>
 				</v-col>
 			</v-row>
@@ -156,6 +175,7 @@ import TextureModal from "./texture-modal.vue";
 import NewTextureModal from "./new-texture-modal/index.vue";
 import RenameVersionModal from "./rename-version-modal.vue";
 import AddVersionModal from "./add-version-modal.vue";
+import MergeTextureModal from "./merge-texture-modal.vue";
 import TextureRemoveConfirm from "./texture-remove-confirm.vue";
 
 import { updatePageStyles } from "@helpers/colors.js";
@@ -168,6 +188,7 @@ export default {
 		RenameVersionModal,
 		NewTextureModal,
 		AddVersionModal,
+		MergeTextureModal,
 		TextureRemoveConfirm,
 	},
 	data() {
@@ -183,6 +204,7 @@ export default {
 			search: "",
 			textureModalOpen: false,
 			renameVersionModalOpen: false,
+			mergeModalOpen: false,
 			modalData: {},
 			remove: {
 				confirm: false,
@@ -236,6 +258,9 @@ export default {
 		},
 		openNewTextureModal() {
 			this.newTextureModalOpen = true;
+		},
+		openMergeModal() {
+			this.mergeModalOpen = true;
 		},
 		askRemove(data) {
 			this.remove.data = data;

--- a/pages/texture/merge-texture-modal.vue
+++ b/pages/texture/merge-texture-modal.vue
@@ -1,0 +1,135 @@
+<template>
+	<modal-form
+		v-model="modalOpened"
+		:title="$root.lang().database.textures.merge_textures.title"
+		:disabled="formIncomplete"
+		danger
+		button-type="confirm"
+		@close="$emit('close')"
+		@submit="send"
+	>
+		<v-alert type="warning" class="px-2" outlined dense>
+			{{ $root.lang().database.textures.merge_textures.warning }}
+		</v-alert>
+		<v-form ref="form" class="pt-2">
+			<v-row>
+				<v-col>
+					<v-text-field
+						v-model="srcTextureID"
+						:color="color"
+						required
+						type="number"
+						:label="$root.lang().database.textures.merge_textures.source"
+						:hint="srcPreview"
+						persistent-hint
+						@change="updateSrc"
+					/>
+				</v-col>
+				<v-col>
+					<v-text-field
+						v-model="destTextureID"
+						:color="color"
+						required
+						type="number"
+						:label="$root.lang().database.textures.merge_textures.destination"
+						:hint="destPreview"
+						persistent-hint
+						@change="updateDest"
+					/>
+				</v-col>
+			</v-row>
+		</v-form>
+	</modal-form>
+</template>
+
+<script>
+import ModalForm from "@components/modal-form.vue";
+import axios from "axios";
+
+export default {
+	name: "merge-texture-modal",
+	components: {
+		ModalForm,
+	},
+	props: {
+		value: {
+			type: Boolean,
+			required: true,
+		},
+		color: {
+			type: String,
+			required: false,
+			default: "primary",
+		},
+	},
+	data() {
+		return {
+			modalOpened: false,
+			srcTextureID: null,
+			srcData: null,
+			destTextureID: null,
+			destData: null,
+		};
+	},
+	methods: {
+		async getTextureData(id) {
+			if (id === null) return null;
+			try {
+				const res = await axios.get(`${this.$root.apiURL}/textures/${id}`);
+				return res.data;
+			} catch {
+				// reject with error property
+				return { error: this.$root.lang().database.textures.merge_textures.invalid_id };
+			}
+		},
+		// separate update methods to debounce the input (only updated on change rather than on input)
+		async updateSrc() {
+			this.srcData = await this.getTextureData(this.srcTextureID);
+		},
+		async updateDest() {
+			this.destData = await this.getTextureData(this.destTextureID);
+		},
+		createPreview(data) {
+			if (data === null) return "";
+			if (data.error) return data.error;
+			return `${data.name} (${data.tags.join(", ")})`;
+		},
+		send() {
+			// /textures/merge/{add_id}/{remove_id} (destination goes first)
+			axios
+				.put(
+					`${this.$root.apiURL}/textures/merge/${this.destTextureID}/${this.srcTextureID}`,
+					null,
+					this.$root.apiOptions,
+				)
+				.then(() => {
+					this.$root.showSnackBar(this.$root.lang().global.ends_success, "success");
+					this.$emit("close");
+				})
+				.catch((err) => {
+					this.$root.showSnackBar(err, "error");
+					this.$emit("close");
+				});
+		},
+	},
+	computed: {
+		srcPreview() {
+			return this.createPreview(this.srcData);
+		},
+		destPreview() {
+			return this.createPreview(this.destData);
+		},
+		formIncomplete() {
+			return this.srcTextureID === null || this.destTextureID === null;
+		},
+	},
+	watch: {
+		value(newValue) {
+			this.modalOpened = newValue;
+		},
+		modalOpened(newValue) {
+			this.$emit("input", newValue);
+		},
+	},
+};
+</script>

--- a/resources/strings/en_US.js
+++ b/resources/strings/en_US.js
@@ -232,6 +232,13 @@ export default {
 				example: "Renames all instances of a Minecraft version in the database (ex. 1.17 → 1.17.1)",
 				warning: "Please don't forget to update all GitHub branch names!",
 			},
+			merge_textures: {
+				title: "Merge textures",
+				warning: "This will delete the source texture and cannot be undone!",
+				source: "Source texture ID",
+				destination: "Destination texture ID",
+				invalid_id: "Invalid texture ID",
+			},
 		},
 		packs: {
 			title: "Packs",


### PR DESCRIPTION
Closes #124 

I ended up implementing this using a button on the page rather than making it per-texture since the implementation worked out more nicely that way.

<img width="1100" alt="Screen Shot 2025-06-16 at 2 51 27 PM" src="https://github.com/user-attachments/assets/f6a10f57-ffe3-452e-89c3-ca85c8d31701" />

Also ended up going with Rolf's suggestion to use source/destination labelling instead of add/remove since it makes way more sense conceptually.

<img width="608" alt="Screen Shot 2025-06-16 at 2 51 40 PM" src="https://github.com/user-attachments/assets/36f88b04-e2f5-4171-bbf4-79c1f35c5fa7" />
